### PR TITLE
adding modification to user extensions and displaying in structured format

### DIFF
--- a/testdata-generator-ui/components/ConfigureNodeEventInfoModal.vue
+++ b/testdata-generator-ui/components/ConfigureNodeEventInfoModal.vue
@@ -20,7 +20,7 @@
     id="configureEventInfoModal"
     title="Add Event Information"
     size="xl"
-    width="200%"
+    width="150%"
     :visible="$store.state.modules.ConfigureNodeEventInfoStore.nodeEventInfoModal"
     modal-class="modal-fullscreen"
     @hide="cancel"

--- a/testdata-generator-ui/components/ConfigureNodeEventInfoModal.vue
+++ b/testdata-generator-ui/components/ConfigureNodeEventInfoModal.vue
@@ -20,7 +20,7 @@
     id="configureEventInfoModal"
     title="Add Event Information"
     size="xl"
-    width="120%"
+    width="200%"
     :visible="$store.state.modules.ConfigureNodeEventInfoStore.nodeEventInfoModal"
     modal-class="modal-fullscreen"
     @hide="cancel"
@@ -914,20 +914,30 @@
               <div
                 v-for="extension in $store.state.modules.ExtensionDataStore.userExtensions"
                 :key="extension.ID"
-                class="form-inline horizontalSpace verticleSpace"
               >
-                <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'userExtension')">
-                <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                  <ExtensionComponent
-                    v-if="extension.dataType == 'complex'"
-                    :extension="extension"
-                  />
-                </span>
-                <span class="horizontalSpace verticleSpace" />
-                <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'userExtension')">
-                  <em class="bi bi-trash" />
-                </button>
+                <tr style="white-space:nowrap">
+                  <td v-if="extension.dataType == 'string'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'userExtension')">
+                  </td>
+
+                  <td v-if="extension.dataType == 'complex'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <ExtensionComponent
+                      v-if="extension.dataType == 'complex'"
+                      :extension="extension"
+                    />
+                  </td>
+
+                  <td>
+                    <button type="button" class="modifyButton" title="Modify User Extension" @click="modifyExtension($event, extension.ID, 'userExtension')">
+                      <em class="bi bi-pencil" />
+                    </button>
+                    <button type="button" class="deleteButton" title="Delete User Extension" @click="deleteExtension($event, extension.ID, 'userExtension')">
+                      <em class="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
               </div>
             </td>
           </tr>
@@ -942,20 +952,30 @@
               <div
                 v-for="extension in $store.state.modules.ExtensionDataStore.ilmd"
                 :key="extension.ID"
-                class="form-inline horizontalSpace verticleSpace"
               >
-                <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ilmd')">
-                <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                  <ExtensionComponent
-                    v-if="extension.dataType == 'complex'"
-                    :extension="extension"
-                  />
-                </span>
-                <span class="horizontalSpace verticleSpace" />
-                <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'ilmd')">
-                  <em class="bi bi-trash" />
-                </button>
+                <tr style="white-space:nowrap">
+                  <td v-if="extension.dataType == 'string'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ilmd')">
+                  </td>
+
+                  <td v-if="extension.dataType == 'complex'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <ExtensionComponent
+                      v-if="extension.dataType == 'complex'"
+                      :extension="extension"
+                    />
+                  </td>
+
+                  <td>
+                    <button type="button" class="modifyButton" title="Modify ILMD Extension" @click="modifyExtension($event, extension.ID, 'ilmd')">
+                      <em class="bi bi-pencil" />
+                    </button>
+                    <button type="button" class="deleteButton" title="Delete ILMD Extension" @click="deleteExtension($event, extension.ID, 'ilmd')">
+                      <em class="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
               </div>
             </td>
           </tr>
@@ -1063,20 +1083,30 @@
               <div
                 v-for="extension in $store.state.modules.ExtensionDataStore.errorExtensions"
                 :key="extension.ID"
-                class="form-inline horizontalSpace verticleSpace"
               >
-                <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ErrorExtension')">
-                <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                  <ExtensionComponent
-                    v-if="extension.dataType == 'complex'"
-                    :extension="extension"
-                  />
-                </span>
-                <span class="horizontalSpace verticleSpace" />
-                <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'ErrorExtension')">
-                  <em class="bi bi-trash" />
-                </button>
+                <tr style="white-space:nowrap">
+                  <td v-if="extension.dataType == 'string'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ErrorExtension')">
+                  </td>
+
+                  <td v-if="extension.dataType == 'complex'">
+                    <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                    <ExtensionComponent
+                      v-if="extension.dataType == 'complex'"
+                      :extension="extension"
+                    />
+                  </td>
+
+                  <td>
+                    <button type="button" class="modifyButton" title="Modify Error Extension" @click="modifyExtension($event, extension.ID, 'ErrorExtension')">
+                      <em class="bi bi-pencil" />
+                    </button>
+                    <button type="button" class="deleteButton" title="Delete Error Extension" @click="deleteExtension($event, extension.ID, 'ErrorExtension')">
+                      <em class="bi bi-trash" />
+                    </button>
+                  </td>
+                </tr>
               </div>
             </td>
           </tr>
@@ -1348,7 +1378,7 @@ export default {
     // Function to add the User extension onclick of the Add button
     userExtensionAddition (event, type) {
       event.preventDefault()
-      this.$store.commit('modules/ExtensionDataStore/toggleExtensionModal')
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
       this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
       this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
     },
@@ -1358,6 +1388,15 @@ export default {
       this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
       this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
       this.$store.commit('modules/ExtensionDataStore/extensionText', { text: event.target.value, extensionID })
+    },
+
+    // Function to modify the User Extension onClick of the modify button
+    modifyExtension (event, extensionID, type) {
+      event.preventDefault()
+      this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
+      this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
+      this.$store.commit('modules/ExtensionDataStore/modifyExtension', extensionID)
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
     },
 
     // Function to delete the User extension onclick of the Delete button
@@ -1487,5 +1526,13 @@ text-align: center;
 
 .errorDimension{
   background-color: #f2c2c2;
+}
+
+.modifyButton{
+  color:#F8C471
+}
+
+.deleteButton{
+  color:#dc3545
 }
 </style>

--- a/testdata-generator-ui/components/ExtensionComponent.vue
+++ b/testdata-generator-ui/components/ExtensionComponent.vue
@@ -20,24 +20,36 @@
     <div
       v-for="extension in extension.complex"
       :key="extension.ID"
-      class="form-inline"
     >
-      <span>{{ extension.namespace + ":" + extension.localName }}</span>
-      <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event,extension.ID)">
-      <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-        <ExtensionComponent
-          v-if="extension.dataType == 'complex'"
-          :extension="extension"
-        />
-      </span>
-      <span class="horizontalSpace verticleSpace" />
-      <button class="btn btn-danger" @click="deleteExtension($event,extension.ID)">
-        <em class="bi bi-trash" />
+      <tr style="white-space:nowrap">
+        <td v-if="extension.dataType == 'string'">
+          <span>{{ extension.namespace + ":" + extension.localName }}</span>
+          <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event,extension.ID)">
+        </td>
+
+        <td v-if="extension.dataType == 'complex'">
+          <span>{{ extension.namespace + ":" + extension.localName }}</span>
+          <ExtensionComponent
+            v-if="extension.dataType == 'complex'"
+            :extension="extension"
+          />
+        </td>
+
+        <td style="width:100%">
+          <button type="button" class="modifyButton" title="Modify Extension" @click="modifyExtension($event, extension.ID)">
+            <em class="bi bi-pencil" />
+          </button>
+          <button type="button" class="deleteButton" title="Delete Extension" @click="deleteExtension($event, extension.ID)">
+            <em class="bi bi-trash" />
+          </button>
+        </td>
+      </tr>
+    </div>
+    <div style="margin-top:8px;">
+      <button @click="addNewExtension($event)">
+        Add another
       </button>
     </div>
-    <button @click="addNewExtension($event)">
-      Add another
-    </button>
   </div>
 </template>
 
@@ -51,6 +63,8 @@ export default {
   props: {
     extension: Object
   },
+  mounted () {
+  },
   created () {
     this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', this.extension.type)
   },
@@ -59,8 +73,18 @@ export default {
       // Add the extension on click of the add button by the user
       event.preventDefault()
       this.$store.commit('modules/ExtensionDataStore/setParentExtension', this.extension)
-      this.$store.commit('modules/ExtensionDataStore/toggleExtensionModal')
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
     },
+
+    modifyExtension (event, extensionID) {
+      // Function to modify the User Extension onClick of the modify button
+      event.preventDefault()
+      this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', this.extension.type)
+      this.$store.commit('modules/ExtensionDataStore/setParentExtension', this.extension)
+      this.$store.commit('modules/ExtensionDataStore/modifyExtension', extensionID)
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
+    },
+
     deleteExtension (event, extensionID) {
       // Delete the extension on click of the delete button by the user
       event.preventDefault()
@@ -86,5 +110,13 @@ export default {
 .verticleSpace{
   padding-top:8px;
   padding-bottom: 8px;
+}
+
+.modifyButton{
+  color:#F8C471
+}
+
+.deleteButton{
+  color:#dc3545
 }
 </style>

--- a/testdata-generator-ui/components/ExtensionModal.vue
+++ b/testdata-generator-ui/components/ExtensionModal.vue
@@ -22,6 +22,7 @@
     size="lg"
     width="100%"
     :visible="$store.state.modules.ExtensionDataStore.extensionModal"
+    @hide="cancel"
   >
     <b-form id="AddExtension" @submit.prevent="submitExtension">
       <div class="form-group">
@@ -41,8 +42,6 @@
           placeholder="https://example.com"
           class="form-control"
           autocomplete="off"
-          oninput="setCustomValidity('');"
-          oninvalid="this.setCustomValidity('Invalid characters in namespace field ex: https://example.com or ns1')"
           required
         >
       </div>
@@ -51,8 +50,6 @@
         <input
           v-model="extension.localName"
           type="text"
-          oninput="setCustomValidity('');"
-          oninvalid="this.setCustomValidity('Invalid characters in local name field ex: myField or bestBeforeDate')"
           class="form-control"
           autocomplete="off"
           required
@@ -97,14 +94,27 @@ export default {
     }
   },
   mounted () {
+    // Check if user is trying to provide new Extension or modifying existing Extension, for modification show the existing information
+    const currentExtensionInfo = JSON.parse(JSON.stringify(this.$store.state.modules.ExtensionDataStore.currentExtensionInfo))
+    if (currentExtensionInfo !== undefined && currentExtensionInfo !== null && Object.keys(currentExtensionInfo).length !== 0) {
+      this.extension = currentExtensionInfo
+    }
   },
   created () {
   },
   methods: {
     submitExtension () {
       // Function to get the data after the submission of modal
-      this.$store.commit('modules/ExtensionDataStore/toggleExtensionModal')
+      this.$store.commit('modules/ExtensionDataStore/hideExtensionModal')
       this.$store.commit('modules/ExtensionDataStore/extensionsAddition', this.extension)
+    },
+
+    // Method to hide the extension on click of the Cancel/ESC button
+    cancel () {
+      // Hide the Extension modal
+      this.$store.commit('modules/ExtensionDataStore/hideExtensionModal')
+      // Reset current extension elements
+      this.$store.commit('modules/ExtensionDataStore/resetCurrentExtensionInfo')
     }
   }
 }

--- a/testdata-generator-ui/pages/CreateTestData.vue
+++ b/testdata-generator-ui/pages/CreateTestData.vue
@@ -1172,20 +1172,30 @@
                 <div
                   v-for="extension in $store.state.modules.ExtensionDataStore.userExtensions"
                   :key="extension.ID"
-                  class="form-inline horizontalSpace verticleSpace"
                 >
-                  <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                  <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'userExtension')">
-                  <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                    <ExtensionComponent
-                      v-if="extension.dataType == 'complex'"
-                      :extension="extension"
-                    />
-                  </span>
-                  <span class="horizontalSpace verticleSpace" />
-                  <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'userExtension')">
-                    <em class="bi bi-trash" />
-                  </button>
+                  <tr style="white-space:nowrap">
+                    <td v-if="extension.dataType == 'string'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'userExtension')">
+                    </td>
+
+                    <td v-if="extension.dataType == 'complex'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <ExtensionComponent
+                        v-if="extension.dataType == 'complex'"
+                        :extension="extension"
+                      />
+                    </td>
+
+                    <td>
+                      <button type="button" class="modifyButton" title="Modify User Extension" @click="modifyExtension($event, extension.ID, 'userExtension')">
+                        <em class="bi bi-pencil" />
+                      </button>
+                      <button type="button" class="deleteButton" title="Delete User Extension" @click="deleteExtension($event, extension.ID, 'userExtension')">
+                        <em class="bi bi-trash" />
+                      </button>
+                    </td>
+                  </tr>
                 </div>
               </td>
             </tr>
@@ -1200,20 +1210,30 @@
                 <div
                   v-for="extension in $store.state.modules.ExtensionDataStore.ilmd"
                   :key="extension.ID"
-                  class="form-inline horizontalSpace verticleSpace"
                 >
-                  <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                  <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ilmd')">
-                  <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                    <ExtensionComponent
-                      v-if="extension.dataType == 'complex'"
-                      :extension="extension"
-                    />
-                  </span>
-                  <span class="horizontalSpace verticleSpace" />
-                  <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'ilmd')">
-                    <em class="bi bi-trash" />
-                  </button>
+                  <tr style="white-space:nowrap">
+                    <td v-if="extension.dataType == 'string'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ilmd')">
+                    </td>
+
+                    <td v-if="extension.dataType == 'complex'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <ExtensionComponent
+                        v-if="extension.dataType == 'complex'"
+                        :extension="extension"
+                      />
+                    </td>
+
+                    <td>
+                      <button type="button" class="modifyButton" title="Modify ILMD Extension" @click="modifyExtension($event, extension.ID, 'ilmd')">
+                        <em class="bi bi-pencil" />
+                      </button>
+                      <button type="button" class="deleteButton" title="Delete ILMD Extension" @click="deleteExtension($event, extension.ID, 'ilmd')">
+                        <em class="bi bi-trash" />
+                      </button>
+                    </td>
+                  </tr>
                 </div>
               </td>
             </tr>
@@ -1321,20 +1341,30 @@
                 <div
                   v-for="extension in $store.state.modules.ExtensionDataStore.errorExtensions"
                   :key="extension.ID"
-                  class="form-inline horizontalSpace verticleSpace"
                 >
-                  <span>{{ extension.namespace + ":" + extension.localName }}</span>
-                  <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ErrorExtension')">
-                  <span v-if="extension.dataType == 'complex'" class="horizontalSpace verticleSpace">
-                    <ExtensionComponent
-                      v-if="extension.dataType == 'complex'"
-                      :extension="extension"
-                    />
-                  </span>
-                  <span class="horizontalSpace verticleSpace" />
-                  <button class="btn btn-danger" @click="deleteExtension($event,extension.ID, 'ErrorExtension')">
-                    <em class="bi bi-trash" />
-                  </button>
+                  <tr style="white-space:nowrap">
+                    <td v-if="extension.dataType == 'string'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <input v-if="extension.dataType == 'string'" :value="extension.text" type="text" @input="extensionText($event, extension.ID, 'ErrorExtension')">
+                    </td>
+
+                    <td v-if="extension.dataType == 'complex'">
+                      <span>{{ extension.namespace + ":" + extension.localName }}</span>
+                      <ExtensionComponent
+                        v-if="extension.dataType == 'complex'"
+                        :extension="extension"
+                      />
+                    </td>
+
+                    <td style="width:100%">
+                      <button type="button" class="modifyButton" title="Modify Error Extension" @click="modifyExtension($event, extension.ID, 'ErrorExtension')">
+                        <em class="bi bi-pencil" />
+                      </button>
+                      <button type="button" class="deleteButton" title="Delete Error Extension" @click="deleteExtension($event, extension.ID, 'ErrorExtension')">
+                        <em class="bi bi-trash" />
+                      </button>
+                    </td>
+                  </tr>
                 </div>
               </td>
             </tr>
@@ -1638,7 +1668,7 @@ export default {
     // Function to add the User extension onclick of the Add button
     userExtensionAddition (event, type) {
       event.preventDefault()
-      this.$store.commit('modules/ExtensionDataStore/toggleExtensionModal')
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
       this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
       this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
     },
@@ -1648,6 +1678,15 @@ export default {
       this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
       this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
       this.$store.commit('modules/ExtensionDataStore/extensionText', { text: event.target.value, extensionID })
+    },
+
+    // Function to modify the User Extension onClick of the modify button
+    modifyExtension (event, extensionID, type) {
+      event.preventDefault()
+      this.$store.commit('modules/ExtensionDataStore/extensionTypePopulator', type)
+      this.$store.commit('modules/ExtensionDataStore/setParentExtension', null)
+      this.$store.commit('modules/ExtensionDataStore/modifyExtension', extensionID)
+      this.$store.commit('modules/ExtensionDataStore/showExtensionModal')
     },
 
     // Function to delete the User extension onclick of the Delete button
@@ -1846,5 +1885,13 @@ text-align: center;
 
 .errorDimension{
   background-color: #f2c2c2;
+}
+
+.modifyButton{
+  color:#F8C471
+}
+
+.deleteButton{
+  color:#dc3545
 }
 </style>

--- a/testdata-generator-ui/store/modules/ExtensionDataStore.js
+++ b/testdata-generator-ui/store/modules/ExtensionDataStore.js
@@ -1,5 +1,5 @@
 // OpenEPCIS Testdata Generator UI
-// Copyright (C) 2022  benelog GmbH & Co. KG 
+// Copyright (C) 2022  benelog GmbH & Co. KG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // See LICENSE in the project root for license information.
 const getDefaultState = () => {
   return {
@@ -26,7 +26,9 @@ const getDefaultState = () => {
     parentIlmd: {},
     errorExtensions: [],
     errorParentExtension: {},
-    errorExtensionCount: 0
+    errorExtensionCount: 0,
+    currentExtensionInfo: null,
+    currentExtensionId: null
   }
 }
 
@@ -42,46 +44,93 @@ export const mutations = {
     // On click of the add extension button populate the extension type
     state.extensionType = extensionType
   },
-  toggleExtensionModal (state) {
-    // Function to show/hide the extension Modal
-    state.extensionModal = !state.extensionModal
+  showExtensionModal (state) {
+    // Function to show the extension Modal
+    state.extensionModal = true
+  },
+  hideExtensionModal (state) {
+    // Function to show the extension Modal
+    state.extensionModal = false
   },
   extensionsAddition (state, extension) {
     // Vales relevent to User Extension add to userExtensions List
     if (state.extensionType === 'userExtension') {
-      extension.ID = state.userExtensionCount
-      if (!state.parentExtension) {
-        state.userExtensions.push(extension)
-      } else {
-        if (state.parentExtension.complex === null) {
-          state.parentExtension.complex = []
+      // On submit of the Extension modaly if user is adding new extension element
+      if (state.currentExtensionId == null && state.currentExtensionInfo == null) {
+        extension.ID = state.userExtensionCount
+        if (!state.parentExtension) {
+          state.userExtensions.push(extension)
+        } else {
+          if (state.parentExtension.complex === null) {
+            state.parentExtension.complex = []
+          }
+          state.parentExtension.complex.push(extension)
         }
-        state.parentExtension.complex.push(extension)
+        state.userExtensionCount++
+      } else {
+        // If user is trying to modify existing extension element information then replace particular extension element
+        let replacementExtensionInfo = null
+        if (!state.parentExtension) {
+          replacementExtensionInfo = state.userExtensions.find(obj => obj.ID === state.currentExtensionId)
+        } else {
+          replacementExtensionInfo = state.parentExtension.complex.find(obj => obj.ID === state.currentExtensionId)
+        }
+        Object.assign(replacementExtensionInfo, extension)
+        state.currentExtensionInfo = null
+        state.currentExtensionId = null
       }
-      state.userExtensionCount++
     } else if (state.extensionType === 'ilmd') {
       // Values relevant to ILMD add to ILMD list
-      extension.ID = state.ilmdCount
-      if (!state.parentIlmd) {
-        state.ilmd.push(extension)
-      } else {
-        if (state.parentIlmd.complex === null) {
-          state.parentIlmd.complex = []
+
+      // On submit of the ILMD Extension modal if user is adding new ILMD extension element
+      if (state.currentExtensionId == null && state.currentExtensionInfo == null) {
+        extension.ID = state.ilmdCount
+        if (!state.parentIlmd) {
+          state.ilmd.push(extension)
+        } else {
+          if (state.parentIlmd.complex === null) {
+            state.parentIlmd.complex = []
+          }
+          state.parentIlmd.complex.push(extension)
         }
-        state.parentIlmd.complex.push(extension)
+        state.ilmdCount++
+      } else {
+        // If user is trying to modify existing extension element information then replace particular extension element
+        let replacementExtensionInfo = null
+        if (!state.parentIlmd) {
+          replacementExtensionInfo = state.ilmd.find(obj => obj.ID === state.currentExtensionId)
+        } else {
+          replacementExtensionInfo = state.parentIlmd.complex.find(obj => obj.ID === state.currentExtensionId)
+        }
+        Object.assign(replacementExtensionInfo, extension)
+        state.currentExtensionInfo = null
+        state.currentExtensionId = null
       }
-      state.ilmdCount++
     } else if (state.extensionType === 'ErrorExtension') {
-      extension.ID = state.errorExtensionCount
-      if (!state.errorParentExtension) {
-        state.errorExtensions.push(extension)
-      } else {
-        if (state.errorParentExtension.complex === null) {
-          state.errorParentExtension.complex = []
+      // On submit of the Extension modaly if user is adding new extension element
+      if (state.currentExtensionId == null && state.currentExtensionInfo == null) {
+        extension.ID = state.errorExtensionCount
+        if (!state.errorParentExtension) {
+          state.errorExtensions.push(extension)
+        } else {
+          if (state.errorParentExtension.complex === null) {
+            state.errorParentExtension.complex = []
+          }
+          state.errorParentExtension.complex.push(extension)
         }
-        state.errorParentExtension.complex.push(extension)
+        state.errorExtensionCount++
+      } else {
+        // If user is trying to modify existing ILMD extension element information then replace particular ILMD extension element
+        let replacementExtensionInfo = null
+        if (!state.errorParentExtension) {
+          replacementExtensionInfo = state.errorExtensions.find(obj => obj.ID === state.currentExtensionId)
+        } else {
+          replacementExtensionInfo = state.errorParentExtension.complex.find(obj => obj.ID === state.currentExtensionId)
+        }
+        Object.assign(replacementExtensionInfo, extension)
+        state.currentExtensionInfo = null
+        state.currentExtensionId = null
       }
-      state.errorExtensionCount++
     }
   },
   setParentExtension (state, extension) {
@@ -134,6 +183,32 @@ export const mutations = {
       }
     }
   },
+
+  modifyExtension (state, extensionID) {
+    // Based on user selection populate the respective extension information to display the modal with current information
+    state.currentExtensionId = extensionID
+
+    if (state.extensionType === 'userExtension') {
+      if (!state.parentExtension) {
+        state.currentExtensionInfo = state.userExtensions.find(obj => obj.ID === extensionID)
+      } else {
+        state.currentExtensionInfo = state.parentExtension.complex.find(obj => obj.ID === extensionID)
+      }
+    } else if (state.extensionType === 'ilmd') {
+      if (!state.parentIlmd) {
+        state.currentExtensionInfo = state.ilmd.find(obj => obj.ID === extensionID)
+      } else {
+        state.currentExtensionInfo = state.parentIlmd.complex.find(obj => obj.ID === extensionID)
+      }
+    } else if (state.extensionType === 'ErrorExtension') {
+      if (!state.errorParentExtension) {
+        state.currentExtensionInfo = state.errorExtensions.find(obj => obj.ID === extensionID)
+      } else {
+        state.currentExtensionInfo = state.errorParentExtension.complex.find(obj => obj.ID === extensionID)
+      }
+    }
+  },
+
   deleteExtension (state, extensionID) {
     // Based on user selection delete the respective extension ID
     if (state.extensionType === 'userExtension') {
@@ -196,6 +271,12 @@ export const mutations = {
     state.userExtensionCount = state.userExtensions.length > 0 ? state.userExtensions.at(-1).ID + 1 : 0
     state.ilmdCount = state.ilmd.length > 0 ? state.ilmd.at(-1).ID + 1 : 0
     state.errorExtensionCount = state.errorExtensions.length > 0 ? state.errorExtensions.at(-1).ID + 1 : 0
+  },
+
+  resetCurrentExtensionInfo (state) {
+    // Reset the resetCurrentExtensionInfo on pressing escape or cancel button in modal
+    state.currentExtensionInfo = null
+    state.currentExtensionId = null
   }
 }
 


### PR DESCRIPTION
Previously, in the Test Data Generator, there was no option to modify the User Extension, ILMD and Error Extension wo now added the feature to modify simple elements as well as complex objects.

Also, previously the complex extensions were displayed in scattered way, now they will be displayed in in a structured manner instead of a scattered way.