### PR TITLE
removing footer and links related to openepcis.

### DIFF
--- a/testdata-generator-ui/pages/index.vue
+++ b/testdata-generator-ui/pages/index.vue
@@ -72,11 +72,6 @@
         </div>
       </section>
     </main>
-    <div class="footerBar">
-      <p>
-        Copyright © 2022 <a href="https://openepcis.io/" target="_blank">OpenEPCIS.io </a> - All Rights Reserved.
-      </p>
-    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Based on the suggestion, I have removed the footer with link to OpenEPCIS website as the website is not live currently. Will be adding the same in the future once it's up and running.