### PR TITLE
Importing the design directly from provided URL within the query parameter

### DIFF
--- a/testdata-generator-rest-api/src/main/resources/application.yml
+++ b/testdata-generator-rest-api/src/main/resources/application.yml
@@ -2,7 +2,8 @@ quarkus:
   swagger-ui:
     always-include: true
   http:
-    cors: true
+    cors:
+      enabled: true
     port: 8080
 
   container-image:

--- a/testdata-generator-ui/assets/css/drawflow.css
+++ b/testdata-generator-ui/assets/css/drawflow.css
@@ -249,7 +249,7 @@ header a {
 .btn-export {
 	float: right;
 	position: absolute;
-	right: 32.5%;
+	right: 24.5%;
 	color: white;
 	font-weight: bold;
 	border: 1px solid #0e5ba3;
@@ -263,7 +263,7 @@ header a {
 .btn-importEvents {
 	float: right;
 	position: absolute;
-	right: 23.5%;
+	right: 15.5%;
 	color: white;
 	font-weight: bold;
 	border: 1px solid #080007;
@@ -277,7 +277,7 @@ header a {
 .btn-import {
 	float: right;
 	position: absolute;
-	right: 15.5%;
+	right: 5.4%;
 	color: white;
 	font-weight: bold;
 	border: 1px solid #012c0e;
@@ -288,10 +288,10 @@ header a {
 	z-index: 5;
 }
 
-.btn-importInputTemplate {
+/* .btn-importInputTemplate {
 	float: right;
 	position: absolute;
-	right:5.5%;
+	right:2%;
 	color: white;
 	font-weight: bold;
 	border: 1px solid #080007;
@@ -300,7 +300,7 @@ header a {
 	border-radius: 4px;
 	cursor: pointer;
 	z-index: 5;
-}
+}*/
 
 .btn-clear {
 	float: right;

--- a/testdata-generator-ui/pages/DesignTestData.vue
+++ b/testdata-generator-ui/pages/DesignTestData.vue
@@ -336,7 +336,7 @@ export default {
       this.designSupplychainFromEvents()
     })
 
-    // If user has passed parameter along with the page URL then query for the url and obtain the data and load the design
+    // If user has passed query parameter along with the page URL then query for the provided url and obtain the data and load the design
     if (this.$route.query.url !== undefined && this.$route.query.url !== null) {
       this.$store.dispatch('modules/DesignTestDataStore/obtainURLData', this.$route.query.url)
       this.$store.commit('modules/DesignTestDataStore/hideImportDesignModal')

--- a/testdata-generator-ui/pages/DesignTestData.vue
+++ b/testdata-generator-ui/pages/DesignTestData.vue
@@ -63,15 +63,15 @@
               title="Import design template from local"
               @click="$refs.readDrawflowInfo.click()"
             >
-              Import Local
+              Import Template
             </div>
           </span>
           <div class="drawflowButton btn-importEvents rounded-pill" title="Import the list of events to design" @click="importEventsList($event)">
             Import Events
           </div>
-          <div class="drawflowButton btn-importInputTemplate rounded-pill" title="Import design template from remote URL" @click="importInputTemplate($event)">
+          <!-- <div class="drawflowButton btn-importInputTemplate rounded-pill" title="Import design template from remote URL" @click="importInputTemplate($event)">
             Import Template
-          </div>
+          </div> -->
           <div class=" drawflowButton btn-clear rounded-pill" title="Clear the design" @click="clearDesignInfo()">
             Clear
           </div>
@@ -211,7 +211,11 @@ export default {
   },
   watch: {
     '$store.state.modules.DesignTestDataStore.importedDesignData' (value) {
-      this.populateImportDesignData(value)
+      if (value !== '' && typeof value === 'string' && value.startsWith('Unable')) {
+        this.$alertify.alert('Design template import failed', value)
+      } else if (value !== '') {
+        this.populateImportDesignData(value)
+      }
     }
   },
   async mounted () {
@@ -331,6 +335,12 @@ export default {
     this.$root.$on('drawSupplyChainDesign', () => {
       this.designSupplychainFromEvents()
     })
+
+    // If user has passed parameter along with the page URL then query for the url and obtain the data and load the design
+    if (this.$route.query.url !== undefined && this.$route.query.url !== null) {
+      this.$store.dispatch('modules/DesignTestDataStore/obtainURLData', this.$route.query.url)
+      this.$store.commit('modules/DesignTestDataStore/hideImportDesignModal')
+    }
   },
   methods: {
     drag (event, eventType) {

--- a/testdata-generator-ui/store/modules/DesignTestDataStore.js
+++ b/testdata-generator-ui/store/modules/DesignTestDataStore.js
@@ -77,7 +77,7 @@ export const actions = {
         commit('populateImportDesignData', response.data)
       })
       .catch((error) => {
-        const message = 'Unable to obtain data, Error : ' + error + '\nPlease check the URL : ' + inputURL
+        const message = 'Unable to obtain data, request failed. \n' + error + '\n Please check the URL : ' + inputURL
         commit('populateImportDesignData', message)
       })
   }


### PR DESCRIPTION
@sboeckelmann 
As discussed yesterday I have added an option to import the design and load to the Test Data Generator front-end directly from provided URL. This should work when we try to access the Test Data Generator design example something like this:

```
https://test-data-generator.openepcis.io/ui/DesignTestData/?url=https%3A%2F%2Fraw.githubusercontent.com%2FAravinda93%2Feveything-hash-FINAL%2Fmain%2Fstatic%2FTest_Data_Generator_Design_2023-05-1016_17_48.029.json
```

Kindly request you to review the changes and approve the PR.