### PR TITLE
adding the test data generator design templates based on GS1 based implementation guidelines

### DIFF
--- a/examples/Design Template for GS1 Implementation Guideline examples/1. Assignment of Identifiers for EPCIS Event From Table 4-6.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/1. Assignment of Identifiers for EPCIS Event From Table 4-6.json
@@ -1,0 +1,177 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 1,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2014-03-15T10:11:12",
+                    "fromTime": "2023-03-02T15:55:02.000",
+                    "toTime": "2023-03-03T15:55:02.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "manually",
+                "readPoint": {
+                    "gcpLength": null,
+                    "manualURI": "urn:epc:id:sgln:9521141.11111.2"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9521141111110",
+                    "extension": "0"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9521345678900",
+                    "extension": "0"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-03T15:55:02.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-02T15:55:02.000",
+                    "ErrorDeclarationTimeTo": "2023-03-03T15:55:02.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 2,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "po",
+                        "bizTransaction": "urn:epcglobal:cbv:bt:5012345678900:1234"
+                    },
+                    {
+                        "ID": 1,
+                        "type": "inv",
+                        "bizTransaction": "urn:epcglobal:cbv:bt:0614141111114:9876"
+                    }
+                ],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "9521141",
+                "serialType": "none",
+                "serialNumber": "0123456789"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "1",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Events",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 450,
+                        "pos_y": 272
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 138,
+                        "pos_y": 230
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/10. Example EPCIS Transformation Event Information Content from Table 5-12.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/10. Example EPCIS Transformation Event Information Content from Table 5-12.json
@@ -1,0 +1,317 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 5,
+            "eventType": "TransformationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "TransformationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-13T16:21:19.000",
+                    "fromTime": "2023-03-12T16:21:19.000",
+                    "toTime": "2023-03-13T16:21:19.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "CREATING_CLASS_INSTANCE",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T16:21:19.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T16:21:19.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T16:21:19.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "87126341248268",
+                "rangeFrom": 10
+            }
+        },
+        {
+            "identifiersId": 9,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Variable Measure Quantity",
+                "uom": "ONZ",
+                "gtin": "15176718798798",
+                "quantity": 12
+            }
+        },
+        {
+            "identifiersId": 10,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Unspecified Quantity",
+                "uom": null,
+                "gtin": "14651656141645"
+            }
+        },
+        {
+            "identifiersId": 11,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12441209812904",
+                "quantity": 999
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "9",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 10,
+            "quantity": 12
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "10",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 100,
+            "quantity": 0
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "11",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 100,
+            "quantity": 999
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 47,
+                        "pos_y": 21
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "TransformationEvent"
+                        },
+                        "class": "TransformationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "9",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "10",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "11",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 486,
+                        "pos_y": 374
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 49,
+                        "pos_y": 247
+                    },
+                    "10": {
+                        "id": 10,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 10,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 52,
+                        "pos_y": 463
+                    },
+                    "11": {
+                        "id": 11,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 11,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 41,
+                        "pos_y": 671
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/11. Example EPCIS Transformation Event Information Content Linked Via Transformation ID from Table 5-13.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/11. Example EPCIS Transformation Event Information Content Linked Via Transformation ID from Table 5-13.json
@@ -1,0 +1,833 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 5,
+            "eventType": "TransformationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "TransformationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-13T16:21:19.000",
+                    "fromTime": "2023-03-12T16:21:19.000",
+                    "toTime": "2023-03-13T16:21:19.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "CREATING_CLASS_INSTANCE",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T16:21:19.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T16:21:19.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T16:21:19.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": [],
+                "transformationXformId": "Xform 123"
+            }
+        },
+        {
+            "eventId": 12,
+            "eventType": "TransformationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "TransformationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-13T17:26:19.000",
+                    "fromTime": "2023-03-12T17:26:19.000",
+                    "toTime": "2023-03-13T17:26:19.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "CREATING_CLASS_INSTANCE",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T17:26:19.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T17:26:19.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T17:26:19.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": [],
+                "transformationXformId": "Xform 123"
+            }
+        },
+        {
+            "eventId": 13,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-13T17:27:36.000",
+                    "fromTime": "2023-03-12T17:27:36.000",
+                    "toTime": "2023-03-13T17:27:36.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T17:27:36.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T17:27:36.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T17:27:36.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 18,
+            "eventType": "TransformationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "TransformationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-04-25T03:57:15.000",
+                    "fromTime": "2023-04-24T03:57:15.000",
+                    "toTime": "2023-04-25T03:57:15.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": null,
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-04-25T03:57:15.000",
+                    "ErrorDeclarationTimeFrom": "2023-04-24T03:57:15.000",
+                    "ErrorDeclarationTimeTo": "2023-04-25T03:57:15.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": [],
+                "transformationXformId": "Xform 123"
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "87126341248268",
+                "rangeFrom": 10
+            }
+        },
+        {
+            "identifiersId": 9,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Variable Measure Quantity",
+                "uom": "ONZ",
+                "gtin": "15176718798798",
+                "quantity": 12
+            }
+        },
+        {
+            "identifiersId": 10,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Unspecified Quantity",
+                "uom": null,
+                "gtin": "14651656141645"
+            }
+        },
+        {
+            "identifiersId": 14,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12312213213242",
+                "quantity": 999
+            }
+        },
+        {
+            "identifiersId": 15,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "12321232132321",
+                "rangeFrom": 1
+            }
+        },
+        {
+            "identifiersId": 16,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Variable Measure Quantity",
+                "uom": "ONZ",
+                "gtin": "12324535435435",
+                "quantity": 12
+            }
+        },
+        {
+            "identifiersId": 17,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Unspecified Quantity",
+                "uom": null,
+                "gtin": "12312321432432"
+            }
+        },
+        {
+            "identifiersId": 19,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12312422142312",
+                "quantity": 999
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "12",
+            "target": "13",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 30,
+            "quantity": 999
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "1",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 2,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "9",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 5,
+            "quantity": 12
+        },
+        {
+            "ID": 7,
+            "name": "connector7",
+            "source": "10",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 40,
+            "quantity": 0
+        },
+        {
+            "ID": 8,
+            "name": "connector8",
+            "source": "14",
+            "target": "12",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 30,
+            "quantity": 999
+        },
+        {
+            "ID": 9,
+            "name": "connector9",
+            "source": "15",
+            "target": "18",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 10,
+            "name": "connector10",
+            "source": "16",
+            "target": "18",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 5,
+            "quantity": 12
+        },
+        {
+            "ID": 11,
+            "name": "connector11",
+            "source": "17",
+            "target": "18",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 60,
+            "quantity": 0
+        },
+        {
+            "ID": 12,
+            "name": "connector12",
+            "source": "19",
+            "target": "18",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 70,
+            "quantity": 999
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 47,
+                        "pos_y": 21
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "TransformationEvent"
+                        },
+                        "class": "TransformationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "9",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "10",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": []
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 458,
+                        "pos_y": 323
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 49,
+                        "pos_y": 247
+                    },
+                    "10": {
+                        "id": 10,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 10,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 52,
+                        "pos_y": 463
+                    },
+                    "12": {
+                        "id": 12,
+                        "name": "Events",
+                        "data": {
+                            "ID": 12,
+                            "eventType": "TransformationEvent"
+                        },
+                        "class": "TransformationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": []
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "14",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "13",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 353,
+                        "pos_y": 705
+                    },
+                    "13": {
+                        "id": 13,
+                        "name": "Events",
+                        "data": {
+                            "ID": 13,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "12",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 601,
+                        "pos_y": 706
+                    },
+                    "14": {
+                        "id": 14,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 14,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "12",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 54,
+                        "pos_y": 704
+                    },
+                    "15": {
+                        "id": 15,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 15,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 841,
+                        "pos_y": 14.88888888888889
+                    },
+                    "16": {
+                        "id": 16,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 16,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 843,
+                        "pos_y": 235
+                    },
+                    "17": {
+                        "id": 17,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 17,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 845,
+                        "pos_y": 455.8888888888889
+                    },
+                    "18": {
+                        "id": 18,
+                        "name": "Events",
+                        "data": {
+                            "ID": 18,
+                            "eventType": "TransformationEvent"
+                        },
+                        "class": "TransformationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "15",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "16",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "17",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "19",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1133,
+                        "pos_y": 218
+                    },
+                    "19": {
+                        "id": 19,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 19,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 848,
+                        "pos_y": 675
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/12. Example EPCIS Event Information Content for Simple Digital Coupon Business Process from Table 5-14.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/12. Example EPCIS Event Information Content for Simple Digital Coupon Business Process from Table 5-14.json
@@ -1,0 +1,290 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T17:38:34",
+                    "fromTime": "2023-03-12T17:38:34.000",
+                    "toTime": "2023-03-13T17:38:34.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "5157111757157",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "COMMISSIONING",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T17:38:34.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T17:38:34.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T17:38:34.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [
+                    {
+                        "type": "ilmd",
+                        "element": "extensionElement",
+                        "dataType": "string",
+                        "namespace": "Loyalty Card",
+                        "localName": "Redeem Date",
+                        "text": "16-07-2022",
+                        "complex": null,
+                        "ID": 0
+                    }
+                ],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 4,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-16T17:42:27",
+                    "fromTime": "2023-03-12T17:42:27.000",
+                    "toTime": "2023-03-13T17:42:27.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "DECOMMISSIONING",
+                "disposition": "INACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "DELETE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T17:42:27.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T17:42:27.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T17:42:27.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "gcn",
+                "gcpLength": 7,
+                "gcp": "7687687",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "4",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 137,
+                        "pos_y": 58
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 438,
+                        "pos_y": 169
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Events",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 722,
+                        "pos_y": 170
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/13. EPCIS Event information content illustrating user:vendor extensions from Table 5-18.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/13. EPCIS Event information content illustrating user:vendor extensions from Table 5-18.json
@@ -1,0 +1,176 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-01-15T10:00",
+                    "fromTime": "2023-03-12T18:04:01.000",
+                    "toTime": "2023-03-13T18:04:01.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "manually",
+                "readPoint": {
+                    "gcpLength": null,
+                    "manualURI": "geo:41.6725,-86.255278"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "INSPECTING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:04:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:04:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:04:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [
+                    {
+                        "type": "userExtension",
+                        "element": "extensionElement",
+                        "dataType": "string",
+                        "namespace": "myvoc",
+                        "localName": "inspector_badge_nr",
+                        "text": "244301128",
+                        "complex": null,
+                        "ID": 0
+                    }
+                ],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 11,
+                "randomMaxLength": 5,
+                "rangeFrom": 101
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 440,
+                        "pos_y": 113
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/14. Correcting an error by adding an ordinary event with a corrective business step from Table 5-19.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/14. Correcting an error by adding an ordinary event with a corrective business step from Table 5-19.json
@@ -1,0 +1,328 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:04:01.000",
+                    "toTime": "2023-03-13T18:04:01.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:04:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:04:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:04:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:11:49.000",
+                    "toTime": "2023-03-13T18:11:49.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "extensionType": "dynamic",
+                    "gln": "1687181687187",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:11:49.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:11:49.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:11:49.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 11,
+                "randomMaxLength": 5,
+                "rangeFrom": 101
+            }
+        },
+        {
+            "identifiersId": 4,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "16751567157157",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5,
+                "rangeFrom": 104
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "4",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 440,
+                        "pos_y": 113
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 237,
+                        "pos_y": 389
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 23,
+                        "pos_y": 300
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/15. Correcting an error by adding an ordinary event from Table 5-20.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/15. Correcting an error by adding an ordinary event from Table 5-20.json
@@ -1,0 +1,332 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:04:01.000",
+                    "toTime": "2023-03-13T18:04:01.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:04:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:04:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:04:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:11:49.000",
+                    "toTime": "2023-03-13T18:11:49.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "extensionType": "dynamic",
+                    "gln": "1687181687187",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1861868428761",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "VOID_SHIPPING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:11:49.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:11:49.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:11:49.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 11,
+                "randomMaxLength": 5,
+                "rangeFrom": 101
+            }
+        },
+        {
+            "identifiersId": 4,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5,
+                "rangeFrom": 103
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "4",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 440,
+                        "pos_y": 113
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 237,
+                        "pos_y": 389
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 23,
+                        "pos_y": 300
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/16. Correcting an error by adding an error declaration event from Table 5-21.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/16. Correcting an error by adding an error declaration event from Table 5-21.json
@@ -1,0 +1,299 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:04:01.000",
+                    "toTime": "2023-03-13T18:04:01.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "DESTROYING",
+                "disposition": "DESTROYED",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:04:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:04:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:04:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": false,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:11:49.000",
+                    "toTime": "2023-03-13T18:11:49.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "yes",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1861868428761",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "DESTROYING",
+                "disposition": "DESTROYED",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "DELETE",
+                "error": {
+                    "ErrorTimeZone": "-05:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": "DID_NOT_OCCUR",
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2022-07-17T14:00",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:11:49.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:11:49.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 11,
+                "randomMaxLength": 5,
+                "rangeFrom": 101
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 440,
+                        "pos_y": 113
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 656,
+                        "pos_y": 108
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/17. Correcting an error by adding an error declaration event from Table 5-22.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/17. Correcting an error by adding an error declaration event from Table 5-22.json
@@ -1,0 +1,441 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:04:01.000",
+                    "toTime": "2023-03-13T18:04:01.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:04:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:04:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:04:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 1,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "po",
+                        "bizTransaction": "456"
+                    }
+                ],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": false,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:11:49.000",
+                    "toTime": "2023-03-13T18:11:49.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "yes",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1861868428761",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8761868167816",
+                    "extension": "1118787871871"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9871186675126",
+                    "extension": "5715817517651"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "-05:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": "DID_NOT_OCCUR",
+                    "errorCorrectiveIdsList": [
+                        {
+                            "ID": 0,
+                            "value": "urn:uuid:b0fd5cf7-9b53-4671-84bb-b878907a9dc7"
+                        }
+                    ],
+                    "errorCorrectiveCount": 1,
+                    "ErrorDeclarationTime": "2022-07-17T13:00",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:11:49.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:11:49.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 1,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "po",
+                        "bizTransaction": "456"
+                    }
+                ],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 5,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-12T18:43:04.000",
+                    "toTime": "2023-03-13T18:43:04.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1687181687187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": true,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:43:04.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:43:04.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:43:04.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 1,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "po",
+                        "bizTransaction": "123"
+                    }
+                ],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "65656560980979",
+                "serialType": "range",
+                "randomType": "NUMERIC",
+                "randomMinLength": 11,
+                "randomMaxLength": 5,
+                "rangeFrom": 101
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "3",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 440,
+                        "pos_y": 113
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 656,
+                        "pos_y": 108
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 913,
+                        "pos_y": 108
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/18. Example 1-Installing components or assemblies into larger items from 5.10.1.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/18. Example 1-Installing components or assemblies into larger items from 5.10.1.json
@@ -1,0 +1,216 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "AssociationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AssociationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-10-12T08:45",
+                    "fromTime": "2023-03-12T18:58:06.000",
+                    "toTime": "2023-03-13T18:58:06.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "6185914191591",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "INSTALLING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:58:06.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:58:06.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:58:06.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "giai",
+                "gcpLength": 7,
+                "serialType": "random",
+                "gcp": "98768714"
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "grai",
+                "gcpLength": 7,
+                "grai": "1465416646164",
+                "serialType": "random",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "2",
+            "hideInheritParentCount": false
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 42,
+                        "pos_y": 252
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "AssociationEvent"
+                        },
+                        "class": "AssociationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 360,
+                        "pos_y": 220
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 154,
+                        "pos_y": 60
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/19. Example 2-Installing components or assemblies into physical locations from 5.10.2.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/19. Example 2-Installing components or assemblies into physical locations from 5.10.2.json
@@ -1,0 +1,216 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "AssociationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AssociationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-10-14T10:55",
+                    "fromTime": "2023-03-12T18:58:06.000",
+                    "toTime": "2023-03-13T18:58:06.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "6185914191591",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "INSTALLING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T18:58:06.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T18:58:06.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T18:58:06.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "giai",
+                "gcpLength": 7,
+                "serialType": "random",
+                "gcp": "98768714"
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "grai",
+                "gcpLength": 7,
+                "grai": "1465416646164",
+                "serialType": "random",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "2",
+            "hideInheritParentCount": false
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 42,
+                        "pos_y": 252
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "AssociationEvent"
+                        },
+                        "class": "AssociationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 360,
+                        "pos_y": 220
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 154,
+                        "pos_y": 60
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/2. Visibility Data Matrix from Table 4-7.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/2. Visibility Data Matrix from Table 4-7.json
@@ -1,0 +1,649 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T15:40:28.000",
+                    "fromTime": "2023-03-05T15:40:28.000",
+                    "toTime": "2023-03-06T15:40:28.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "extensionType": "dynamic",
+                    "gln": "1234567890123",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "extensionType": "dynamic",
+                    "gln": "1234567890456",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "COMMISSIONING",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T15:40:28.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T15:40:28.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T15:40:28.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 4,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T15:47:24.000",
+                    "fromTime": "2023-03-05T15:47:24.000",
+                    "toTime": "2023-03-06T15:47:24.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1234567890678",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "0987654321234",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "COMMISSIONING",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T15:47:24.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T15:47:24.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T15:47:24.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 5,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": "1",
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T15:53:05.000",
+                    "fromTime": "2023-03-05T15:53:05.000",
+                    "toTime": "2023-03-06T15:53:05.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "6789651423678",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "8765123450981",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T15:53:05.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T15:53:05.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T15:53:05.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 8,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T15:56:41.000",
+                    "fromTime": "2023-03-05T15:56:41.000",
+                    "toTime": "2023-03-06T15:56:41.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "7865341209876",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "7812367126873",
+                    "extension": "1"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "7777782223222",
+                    "extension": "2"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T15:56:41.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T15:56:41.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T15:56:41.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 2,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "po",
+                        "bizTransaction": "67674823229291811"
+                    },
+                    {
+                        "ID": 1,
+                        "type": "inv",
+                        "bizTransaction": "09988787776554454"
+                    }
+                ],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "random",
+                "sgtin": "12345678789890",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "random",
+                "gcp": "234567"
+            }
+        },
+        {
+            "identifiersId": 7,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "1234567",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "4",
+            "hideInheritParentCount": true,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "2",
+            "target": "4",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "4",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "7",
+            "target": "5",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 7,
+            "name": "connector7",
+            "source": "5",
+            "target": "8",
+            "hideInheritParentCount": true,
+            "epcCount": 1,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 12,
+                        "pos_y": 34
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 190,
+                        "pos_y": 235
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 378,
+                        "pos_y": 33
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Events",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 565,
+                        "pos_y": 236
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "8",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 889,
+                        "pos_y": 228
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 704,
+                        "pos_y": 37
+                    },
+                    "8": {
+                        "id": 8,
+                        "name": "Events",
+                        "data": {
+                            "ID": 8,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1152,
+                        "pos_y": 228
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/20. Sensor Example 1-Control or prove temperature compliance from 5.11.1.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/20. Sensor Example 1-Control or prove temperature compliance from 5.11.1.json
@@ -1,0 +1,597 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 6,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-15T08:00:11",
+                    "fromTime": "2023-03-12T19:09:11.000",
+                    "toTime": "2023-03-13T19:09:11.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1961687186187",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1987656134314",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "STORING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T19:09:11.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T19:09:11.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T19:09:11.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-15T07:55",
+                            "endTime": "2022-06-15T07:59"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "12",
+                                "maxValue": "12.1",
+                                "uom": "CEL"
+                            }
+                        ],
+                        "ID": 0
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 7,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-15T08:15:38",
+                    "fromTime": "2023-03-12T19:11:38.000",
+                    "toTime": "2023-03-13T19:11:38.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1184154535614",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "7643191614561",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "STORING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T19:11:38.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T19:11:38.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T19:11:38.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-15T08:10",
+                            "endTime": "2022-06-15T08:14"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "12.1",
+                                "maxValue": "12.2",
+                                "uom": "CEL"
+                            }
+                        ],
+                        "ID": 0
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 8,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-15T17:45:27",
+                    "fromTime": "2023-03-12T19:13:27.000",
+                    "toTime": "2023-03-13T19:13:27.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1871681818618",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "8765310981311",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businessStep": "STORING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T19:13:27.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T19:13:27.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T19:13:27.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-15T17:35",
+                            "endTime": "2022-06-15T17:55"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "9.2",
+                                "maxValue": "9.4",
+                                "uom": "CEL"
+                            }
+                        ],
+                        "ID": 1
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 9,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-15T23:59:47",
+                    "fromTime": "2023-03-12T19:14:47.000",
+                    "toTime": "2023-03-13T19:14:47.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1877678687678",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SENSOR_REPORTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T19:14:47.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T19:14:47.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T19:14:47.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-14T23:59",
+                            "endTime": "2022-06-15T23:59"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "9.1",
+                                "maxValue": "9.4",
+                                "uom": "CEL"
+                            }
+                        ],
+                        "ID": 1
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "176576571",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "1",
+            "target": "6",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "6",
+            "target": "7",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "7",
+            "target": "8",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "8",
+            "target": "9",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Events",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 398,
+                        "pos_y": 142
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "Events",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "8",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 652,
+                        "pos_y": 137
+                    },
+                    "8": {
+                        "id": 8,
+                        "name": "Events",
+                        "data": {
+                            "ID": 8,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 873,
+                        "pos_y": 133
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Events",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "8",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1142,
+                        "pos_y": 132
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/21. Sensor example 2-Exception notification from 5.11.2.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/21. Sensor example 2-Exception notification from 5.11.2.json
@@ -1,0 +1,187 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 9,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-23T11:19",
+                    "fromTime": "2023-03-12T19:14:47.000",
+                    "toTime": "2023-03-13T19:14:47.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1877678687678",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SENSOR_REPORTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T19:14:47.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T19:14:47.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T19:14:47.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {},
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "stringValue": "15.1",
+                                "uom": "CEL"
+                            }
+                        ],
+                        "ID": 2
+                    },
+                    {
+                        "sensorMetadata": {},
+                        "sensorReport": [
+                            {
+                                "type": "User_Defined_Sensor",
+                                "stringValue": "ALARM_CONDITION",
+                                "uriValue": "https://example.com/alarmCodes/temperatureExceeded"
+                            }
+                        ],
+                        "ID": 3
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "176576571",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 7,
+            "name": "connector7",
+            "source": "1",
+            "target": "9",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 15,
+                        "pos_y": 28
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Events",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 280,
+                        "pos_y": 69
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/22. Sensor example 3-Condition monitoring and tracking of intermodal transports from 5.11.3.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/22. Sensor example 3-Condition monitoring and tracking of intermodal transports from 5.11.3.json
@@ -1,0 +1,1611 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 1,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T08:00",
+                    "fromTime": "2023-03-12T20:02:07.000",
+                    "toTime": "2023-03-13T20:02:07.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1465146166144",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-13T20:02:07.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-12T20:02:07.000",
+                    "ErrorDeclarationTimeTo": "2023-03-13T20:02:07.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 4,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T09:15",
+                    "fromTime": "2023-03-14T19:20:16.000",
+                    "toTime": "2023-03-15T19:20:16.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "6571876141757",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "LOADING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T19:20:16.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T19:20:16.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T19:20:16.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 7,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T09:45",
+                    "fromTime": "2023-03-14T19:23:19.000",
+                    "toTime": "2023-03-15T19:23:19.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1876876876186",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "LOADING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T19:23:19.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T19:23:19.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T19:23:19.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 9,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T14:20",
+                    "fromTime": "2023-03-14T19:25:18.000",
+                    "toTime": "2023-03-15T19:25:18.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "4198241411122",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "ARRIVING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T19:25:18.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T19:25:18.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T19:25:18.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 15,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T14:55",
+                    "fromTime": "2023-03-14T20:14:57.000",
+                    "toTime": "2023-03-15T20:14:57.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1876818168681",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "UNLOADING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "DELETE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T20:14:57.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T20:14:57.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T20:14:57.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 16,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T17:11",
+                    "fromTime": "2023-03-14T20:21:18.000",
+                    "toTime": "2023-03-15T20:21:18.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1978971779791",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "LOADING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T20:21:18.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T20:21:18.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T20:21:18.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 18,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-25T04:00",
+                    "fromTime": "2023-03-14T20:26:04.000",
+                    "toTime": "2023-03-15T20:26:04.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1816816876186",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "DEPARTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T20:26:04.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T20:26:04.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T20:26:04.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-23T23:59:59",
+                            "endTime": "2022-06-24T23:59:59"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "8.1",
+                                "maxValue": "21.8",
+                                "uom": "CEL"
+                            },
+                            {
+                                "type": "Humidity",
+                                "minValue": "6.1",
+                                "maxValue": "8.2",
+                                "uom": "A93"
+                            }
+                        ],
+                        "ID": 0
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 19,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-24T23:59:59",
+                    "fromTime": "2023-03-14T20:34:31.000",
+                    "toTime": "2023-03-15T20:34:31.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SENSOR_REPORTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T20:34:31.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T20:34:31.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T20:34:31.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T02:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "53.553747"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "8.562372"
+                            }
+                        ],
+                        "ID": 5
+                    },
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T06:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "53.882318"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "8.099310"
+                            }
+                        ],
+                        "ID": 6
+                    },
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T10:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "54.172892"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "7.094428"
+                            }
+                        ],
+                        "ID": 7
+                    },
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T14:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "54.389794"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "5.753072"
+                            }
+                        ],
+                        "ID": 8
+                    },
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T18:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "54.790116"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "3.407863"
+                            }
+                        ],
+                        "ID": 9
+                    },
+                    {
+                        "sensorMetadata": {
+                            "time": "2022-06-25T22:00"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Latitude",
+                                "stringValue": "56.196056"
+                            },
+                            {
+                                "type": "Longitude",
+                                "stringValue": "1.490934"
+                            }
+                        ],
+                        "ID": 10
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 20,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-25T23:59:59",
+                    "fromTime": "2023-03-14T21:10:57.000",
+                    "toTime": "2023-03-15T21:10:57.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SENSOR_REPORTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T21:10:57.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T21:10:57.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T21:10:57.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "startTime": "2022-06-24T23:59:59",
+                            "endTime": "2022-06-25T23:59:59"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Temperature",
+                                "minValue": "5.6",
+                                "maxValue": "14.9",
+                                "uom": "CEL"
+                            },
+                            {
+                                "type": "Humidity",
+                                "minValue": "4.6",
+                                "maxValue": "3.3",
+                                "uom": "23"
+                            }
+                        ],
+                        "ID": 0
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 21,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-06-25T23:59:59",
+                    "fromTime": "2023-03-14T21:14:41.000",
+                    "toTime": "2023-03-15T21:14:41.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SENSOR_REPORTING",
+                "disposition": null,
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T21:14:41.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T21:14:41.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T21:14:41.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 2,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "random",
+                "sgtin": "15647771756587",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "98779811",
+                "serialType": "random"
+            }
+        },
+        {
+            "identifiersId": 6,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "bic",
+                "gcpLength": null,
+                "bic": "uzuiq76699"
+            }
+        },
+        {
+            "identifiersId": 8,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "giai",
+                "gcpLength": 7,
+                "gcp": "198769879",
+                "serialType": "random"
+            }
+        },
+        {
+            "identifiersId": 14,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "giai",
+                "gcpLength": 7,
+                "serialType": "random",
+                "gcp": "1765761"
+            }
+        },
+        {
+            "identifiersId": 17,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "imovn",
+                "gcpLength": 7,
+                "imovnOption": "imovnOptionA",
+                "imovn": "1576711"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "2",
+            "target": "1",
+            "hideInheritParentCount": true,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "1",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "1",
+            "target": "4",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "6",
+            "target": "4",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "4",
+            "target": "7",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "8",
+            "target": "7",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 7,
+            "name": "connector7",
+            "source": "7",
+            "target": "9",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "9",
+            "target": "15",
+            "hideInheritParentCount": true,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "14",
+            "target": "15",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "17",
+            "target": "16",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "16",
+            "target": "18",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "18",
+            "target": "19",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "15",
+            "target": "16",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "19",
+            "target": "20",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "20",
+            "target": "21",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Events",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 349,
+                        "pos_y": 165
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 11,
+                        "pos_y": 100
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 180,
+                        "pos_y": 10
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Events",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 531,
+                        "pos_y": 160
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 349,
+                        "pos_y": 9
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "Events",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "8",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 724,
+                        "pos_y": 152
+                    },
+                    "8": {
+                        "id": 8,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 8,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 520,
+                        "pos_y": 9
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Events",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "15",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 922,
+                        "pos_y": 147
+                    },
+                    "14": {
+                        "id": 14,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 14,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "15",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 1084,
+                        "pos_y": 61
+                    },
+                    "15": {
+                        "id": 15,
+                        "name": "Events",
+                        "data": {
+                            "ID": 15,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "14",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "16",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 1253,
+                        "pos_y": 176
+                    },
+                    "16": {
+                        "id": 16,
+                        "name": "Events",
+                        "data": {
+                            "ID": 16,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "17",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "15",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 324,
+                        "pos_y": 480
+                    },
+                    "17": {
+                        "id": 17,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 17,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "16",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 6,
+                        "pos_y": 338
+                    },
+                    "18": {
+                        "id": 18,
+                        "name": "Events",
+                        "data": {
+                            "ID": 18,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "16",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "19",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 539,
+                        "pos_y": 486
+                    },
+                    "19": {
+                        "id": 19,
+                        "name": "Events",
+                        "data": {
+                            "ID": 19,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "18",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "20",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 750,
+                        "pos_y": 490
+                    },
+                    "20": {
+                        "id": 20,
+                        "name": "Events",
+                        "data": {
+                            "ID": 20,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "19",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "21",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 949,
+                        "pos_y": 481
+                    },
+                    "21": {
+                        "id": 21,
+                        "name": "Events",
+                        "data": {
+                            "ID": 21,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "20",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1165,
+                        "pos_y": 481
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/23. Sensor example 4-Condition monitoring and tracking of intermodal transports from 5.11.4.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/23. Sensor example 4-Condition monitoring and tracking of intermodal transports from 5.11.4.json
@@ -1,0 +1,194 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 1,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-08-10T08:10",
+                    "fromTime": "2023-03-14T21:19:13.000",
+                    "toTime": "2023-03-15T21:19:13.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1298789217372",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "INSPECTING",
+                "disposition": "CONFORMANT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-15T21:19:13.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-14T21:19:13.000",
+                    "ErrorDeclarationTimeTo": "2023-03-15T21:19:13.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 2,
+                "businessTransactionList": [
+                    {
+                        "ID": 0,
+                        "type": "testprd",
+                        "bizTransaction": "QUZTUZTU"
+                    },
+                    {
+                        "ID": 1,
+                        "type": "testres",
+                        "bizTransaction": "SUCCESSFUL"
+                    }
+                ],
+                "sensorElementList": [
+                    {
+                        "sensorMetadata": {
+                            "deviceID": "GIAI"
+                        },
+                        "sensorReport": [
+                            {
+                                "type": "Dimensionless_concentration",
+                                "value": "18"
+                            },
+                            {
+                                "type": "Dimensionless_concentration",
+                                "value": "10.1"
+                            }
+                        ],
+                        "ID": 0
+                    }
+                ],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 2,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "lgtin",
+                "gcpLength": 7,
+                "quantityType": null,
+                "uom": null,
+                "lgtin": "15751771987179",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "2",
+            "target": "1",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Events",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 424,
+                        "pos_y": 73
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 152,
+                        "pos_y": 30
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/3. EPCIS Aggregation Event Information Content from Table 5-3.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/3. EPCIS Aggregation Event Information Content from Table 5-3.json
@@ -1,0 +1,735 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": "1",
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T17:50:04.000",
+                    "fromTime": "2023-03-05T17:50:04.000",
+                    "toTime": "2023-03-06T17:50:04.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T17:50:04.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T17:50:04.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T17:50:04.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 5,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T17:50:56.000",
+                    "fromTime": "2023-03-05T17:50:56.000",
+                    "toTime": "2023-03-06T17:50:56.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T17:50:56.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T17:50:56.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T17:50:56.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 6,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-06T18:02:47.000",
+                    "fromTime": "2023-03-05T18:02:47.000",
+                    "toTime": "2023-03-06T18:02:47.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "RECEIVING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-06T18:02:47.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-05T18:02:47.000",
+                    "ErrorDeclarationTimeTo": "2023-03-06T18:02:47.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 12,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-04-24T19:51:49.000",
+                    "fromTime": "2023-04-23T19:51:49.000",
+                    "toTime": "2023-04-24T19:51:49.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "UNPACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "DELETE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-04-24T19:51:49.000",
+                    "ErrorDeclarationTimeFrom": "2023-04-23T19:51:49.000",
+                    "ErrorDeclarationTimeTo": "2023-04-24T19:51:49.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 13,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-04-24T19:51:57.000",
+                    "fromTime": "2023-04-23T19:51:57.000",
+                    "toTime": "2023-04-24T19:51:57.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "UNPACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "DELETE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-04-24T19:51:57.000",
+                    "ErrorDeclarationTimeFrom": "2023-04-23T19:51:57.000",
+                    "ErrorDeclarationTimeTo": "2023-04-24T19:51:57.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "random",
+                "gcp": "1234567"
+            },
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "range",
+                "gcp": "6514232222",
+                "rangeFrom": 200
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "34565433256664",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5,
+                "rangeFrom": 1
+            }
+        },
+        {
+            "identifiersId": 7,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "range",
+                "gcp": "6514232222",
+                "rangeFrom": 200
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "2",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 5,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "7",
+            "target": "6",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "5",
+            "target": "6",
+            "hideInheritParentCount": true,
+            "epcCount": 5,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "3",
+            "target": "2",
+            "hideInheritParentCount": true,
+            "epcCount": 5,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "6",
+            "target": "12",
+            "hideInheritParentCount": true,
+            "epcCount": 2,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "6",
+            "target": "13",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 21,
+                        "pos_y": 57
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 323,
+                        "pos_y": 240
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 25,
+                        "pos_y": 207
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 546,
+                        "pos_y": 239
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Events",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "12",
+                                        "output": "input_2"
+                                    },
+                                    {
+                                        "node": "13",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 784,
+                        "pos_y": 240
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 530,
+                        "pos_y": 51
+                    },
+                    "12": {
+                        "id": 12,
+                        "name": "Events",
+                        "data": {
+                            "ID": 12,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": []
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1064,
+                        "pos_y": 141
+                    },
+                    "13": {
+                        "id": 13,
+                        "name": "Events",
+                        "data": {
+                            "ID": 13,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": []
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1069,
+                        "pos_y": 291
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/4. EPCIS Aggregation Event Information Content for a Two-Level Hierarchy from Table 5-4.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/4. EPCIS Aggregation Event Information Content for a Two-Level Hierarchy from Table 5-4.json
@@ -1,0 +1,816 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": "1",
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T17:57:51.000",
+                    "fromTime": "2023-03-06T17:57:51.000",
+                    "toTime": "2023-03-07T17:57:51.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T17:57:51.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T17:57:51.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T17:57:51.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 6,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T18:21:16.000",
+                    "fromTime": "2023-03-06T18:21:16.000",
+                    "toTime": "2023-03-07T18:21:16.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T18:21:16.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T18:21:16.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T18:21:16.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 9,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T18:35:01.000",
+                    "fromTime": "2023-03-06T18:35:01.000",
+                    "toTime": "2023-03-07T18:35:01.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T18:35:01.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T18:35:01.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T18:35:01.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 11,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T18:26:42.000",
+                    "fromTime": "2023-03-06T18:26:42.000",
+                    "toTime": "2023-03-07T18:26:42.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T18:26:42.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T18:26:42.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T18:26:42.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "12345667886756",
+                "randomMinLength": 1,
+                "randomMaxLength": 5,
+                "randomType": "NUMERIC",
+                "rangeFrom": 1
+            }
+        },
+        {
+            "identifiersId": 3,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "10111111111111",
+                "serialNumber": "111111",
+                "rangeFrom": 101
+            }
+        },
+        {
+            "identifiersId": 4,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "10222222222222",
+                "rangeFrom": 102
+            }
+        },
+        {
+            "identifiersId": 5,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "57512751271257",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5,
+                "rangeFrom": 6
+            }
+        },
+        {
+            "identifiersId": 7,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "rangeFrom": 11,
+                "sgtin": "10345446664646",
+                "randomType": "NUMERIC",
+                "randomMinLength": 1,
+                "randomMaxLength": 5
+            }
+        },
+        {
+            "identifiersId": 8,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "10334343433444",
+                "rangeFrom": 103
+            }
+        },
+        {
+            "identifiersId": 10,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "range",
+                "gcp": "100000011",
+                "rangeFrom": 1001
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 5,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "3",
+            "target": "2",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "4",
+            "target": "6",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "5",
+            "target": "6",
+            "hideInheritParentCount": false,
+            "epcCount": 5,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "8",
+            "target": "9",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 6,
+            "name": "connector6",
+            "source": "7",
+            "target": "9",
+            "hideInheritParentCount": true,
+            "epcCount": 5,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 10,
+            "name": "connector10",
+            "source": "10",
+            "target": "11",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 11,
+            "name": "connector11",
+            "source": "2",
+            "target": "11",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 12,
+            "name": "connector12",
+            "source": "6",
+            "target": "11",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 13,
+            "name": "connector13",
+            "source": "9",
+            "target": "11",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 65,
+                        "pos_y": 157
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "11",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 424,
+                        "pos_y": 119
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 78,
+                        "pos_y": 15
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 61,
+                        "pos_y": 349
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 53,
+                        "pos_y": 522
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Events",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "11",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 426,
+                        "pos_y": 465
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 66,
+                        "pos_y": 978
+                    },
+                    "8": {
+                        "id": 8,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 8,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "9",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 50,
+                        "pos_y": 793
+                    },
+                    "9": {
+                        "id": 9,
+                        "name": "Events",
+                        "data": {
+                            "ID": 9,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "8",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "11",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 406,
+                        "pos_y": 909
+                    },
+                    "10": {
+                        "id": 10,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 10,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "11",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 914,
+                        "pos_y": 155
+                    },
+                    "11": {
+                        "id": 11,
+                        "name": "Events",
+                        "data": {
+                            "ID": 11,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "10",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "9",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1280,
+                        "pos_y": 495
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/5. EPCIS Event Information Content for Drop Shipment Scenario from Table 5-6.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/5. EPCIS Event Information Content for Drop Shipment Scenario from Table 5-6.json
@@ -1,0 +1,296 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T19:07:00.000",
+                    "fromTime": "2023-03-06T19:07:00.000",
+                    "toTime": "2023-03-07T19:07:00.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "extensionType": "dynamic",
+                    "gln": "7615151416176",
+                    "extensionFrom": "1",
+                    "extensionFormat": "4"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "1576157617157",
+                    "extension": "1"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "8767868768769",
+                    "extension": "2"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T19:07:00.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T19:07:00.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T19:07:00.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 4,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-07T19:10:59.000",
+                    "fromTime": "2023-03-06T19:10:59.000",
+                    "toTime": "2023-03-07T19:10:59.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1876876786971",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "2"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1576576567675",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "2"
+                },
+                "businessStep": "ARRIVING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "1687618618616",
+                    "extension": "1"
+                },
+                "destinations": {
+                    "type": "OWNING_PARTY",
+                    "glnType": "SGLN",
+                    "gcpLength": 7,
+                    "gln": "9877197179817",
+                    "extension": "1"
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-07T19:10:59.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-06T19:10:59.000",
+                    "ErrorDeclarationTimeTo": "2023-03-07T19:10:59.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "serialType": "range",
+                "gcp": "12133221",
+                "rangeFrom": 111
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "2",
+            "target": "4",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 159,
+                        "pos_y": 54
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 438,
+                        "pos_y": 189
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Events",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 707,
+                        "pos_y": 181
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/6. EPCIS Event Information Content Using Class-Level Identification from Table 5-7.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/6. EPCIS Event Information Content Using Class-Level Identification from Table 5-7.json
@@ -1,0 +1,530 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": "1",
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-07T16:38:32.000",
+                    "toTime": "2023-03-08T16:38:32.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1878970909817",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1980987370391",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "CREATING_CLASS_INSTANCE",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:38:32.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:38:32.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:38:32.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-16T10:00",
+                    "fromTime": "2023-03-07T16:45:36.000",
+                    "toTime": "2023-03-08T16:45:36.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1988979798797",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:45:36.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:45:36.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:45:36.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 4,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-17T10:00",
+                    "fromTime": "2023-03-07T16:47:56.000",
+                    "toTime": "2023-03-08T16:47:56.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1990098108091",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:47:56.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:47:56.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:47:56.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 5,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-25T10:00",
+                    "fromTime": "2023-03-07T16:50:17.000",
+                    "toTime": "2023-03-08T16:50:17.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "8763868736184",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1981981987198",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "RECEIVING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:50:17.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:50:17.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:50:17.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12000000000000",
+                "quantity": 12
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 20,
+            "quantity": 12
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 10,
+            "quantity": 12
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "2",
+            "target": "4",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 10,
+            "quantity": 12
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "3",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 10,
+            "quantity": 12
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 22,
+                        "pos_y": 18
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    },
+                                    {
+                                        "node": "4",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 233,
+                        "pos_y": 111
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 560,
+                        "pos_y": 54
+                    },
+                    "4": {
+                        "id": 4,
+                        "name": "Events",
+                        "data": {
+                            "ID": 4,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 564,
+                        "pos_y": 259
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 833,
+                        "pos_y": 120
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/7. EPCIS Event Information Content for Aggregation of Children Identified at Class Level from Table 5-8.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/7. EPCIS Event Information Content for Aggregation of Children Identified at Class Level from Table 5-8.json
@@ -1,0 +1,492 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 3,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:44:00.000",
+                    "fromTime": "2023-03-09T16:44:00.000",
+                    "toTime": "2023-03-10T16:44:00.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:44:00.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:44:00.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:44:00.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 6,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:45:21.000",
+                    "fromTime": "2023-03-09T16:45:21.000",
+                    "toTime": "2023-03-10T16:45:21.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:45:21.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:45:21.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:45:21.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 7,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:45:53.000",
+                    "fromTime": "2023-03-09T16:45:53.000",
+                    "toTime": "2023-03-10T16:45:53.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "RECEIVING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:45:53.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:45:53.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:45:53.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12000000000000",
+                "quantity": 12
+            }
+        },
+        {
+            "identifiersId": 2,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "15000000000000",
+                "quantity": 52
+            }
+        },
+        {
+            "identifiersId": 5,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "126512816",
+                "serialType": "random"
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 10,
+            "quantity": 12
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 20,
+            "quantity": 52
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "5",
+            "target": "3",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "3",
+            "target": "6",
+            "hideInheritParentCount": false,
+            "epcCount": 0,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "6",
+            "target": "7",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 35,
+                        "pos_y": 8
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 39,
+                        "pos_y": 232
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 399,
+                        "pos_y": 253
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 240,
+                        "pos_y": 13
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Events",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 642,
+                        "pos_y": 250
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "Events",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 957,
+                        "pos_y": 257
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/8. EPCIS Aggregation Event Information Content with Children Identified at Both Instance and Class from Table 5-9.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/8. EPCIS Aggregation Event Information Content with Children Identified at Both Instance and Class from Table 5-9.json
@@ -1,0 +1,542 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 3,
+            "eventType": "AggregationEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "AggregationEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:44:00.000",
+                    "fromTime": "2023-03-09T16:44:00.000",
+                    "toTime": "2023-03-10T16:44:00.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "PACKING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:44:00.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:44:00.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:44:00.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 6,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:45:21.000",
+                    "fromTime": "2023-03-09T16:45:21.000",
+                    "toTime": "2023-03-10T16:45:21.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:45:21.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:45:21.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:45:21.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 7,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2023-03-10T16:45:53.000",
+                    "fromTime": "2023-03-09T16:45:53.000",
+                    "toTime": "2023-03-10T16:45:53.000",
+                    "timeZoneOffset": "+02:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": null,
+                "readPoint": {
+                    "gcpLength": null
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "RECEIVING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-10T16:45:53.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-09T16:45:53.000",
+                    "ErrorDeclarationTimeTo": "2023-03-10T16:45:53.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 1,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "12011111111111",
+                "quantity": 10
+            }
+        },
+        {
+            "identifiersId": 2,
+            "identifierSyntax": "URN",
+            "classData": {
+                "identifierType": "gtin",
+                "gcpLength": 7,
+                "quantityType": "Fixed Measure Quantity",
+                "uom": null,
+                "gtin": "15000324124121",
+                "quantity": 20
+            }
+        },
+        {
+            "identifiersId": 5,
+            "identifierSyntax": "URN",
+            "parentData": {
+                "identifierType": "sscc",
+                "gcpLength": 7,
+                "gcp": "126512816",
+                "serialType": "random"
+            }
+        },
+        {
+            "identifiersId": 8,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "serialType": "range",
+                "sgtin": "12213123213123",
+                "rangeFrom": 101
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "1",
+            "target": "3",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 10
+        },
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": true,
+            "epcCount": 0,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 20
+        },
+        {
+            "ID": 3,
+            "name": "connector3",
+            "source": "5",
+            "target": "3",
+            "hideInheritParentCount": false
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "3",
+            "target": "6",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 30
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "6",
+            "target": "7",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 1,
+            "classCount": 0,
+            "quantity": 30
+        },
+        {
+            "ID": 1,
+            "name": "connector1",
+            "source": "8",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 3,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "1": {
+                        "id": 1,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 1,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 35,
+                        "pos_y": 8
+                    },
+                    "2": {
+                        "id": 2,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 39,
+                        "pos_y": 232
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "AggregationEvent"
+                        },
+                        "class": "AggregationEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            },
+                            "input_2": {
+                                "connections": [
+                                    {
+                                        "node": "1",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    },
+                                    {
+                                        "node": "8",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 457,
+                        "pos_y": 251
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "ParentIdentifiers",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ParentID"
+                        },
+                        "class": "ParentID",
+                        "html": "ParentIdentifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 314,
+                        "pos_y": 27
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Events",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "7",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 726,
+                        "pos_y": 247
+                    },
+                    "7": {
+                        "id": 7,
+                        "name": "Events",
+                        "data": {
+                            "ID": 7,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 1118,
+                        "pos_y": 238
+                    },
+                    "8": {
+                        "id": 8,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 8,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_2"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 35,
+                        "pos_y": 465
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/9. EPCIS Event Information Content Showing Instance:Lot Master Data (ILMD) from Table 5-10.json
+++ b/examples/Design Template for GS1 Implementation Guideline examples/9. EPCIS Event Information Content Showing Instance:Lot Master Data (ILMD) from Table 5-10.json
@@ -1,0 +1,432 @@
+{
+    "eventNodeInfo": [
+        {
+            "eventId": 2,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": "1",
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-15T10:00",
+                    "fromTime": "2023-03-07T16:38:32.000",
+                    "toTime": "2023-03-08T16:38:32.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1872342423423",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1965327652367",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "COMMISSIONING",
+                "disposition": "ACTIVE",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "ADD",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:38:32.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:38:32.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:38:32.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [
+                    {
+                        "type": "ilmd",
+                        "element": "extensionElement",
+                        "dataType": "string",
+                        "namespace": "https://example.com",
+                        "localName": "Expiration_date",
+                        "text": "12-04-2024",
+                        "complex": null,
+                        "ID": 0
+                    },
+                    {
+                        "type": "ilmd",
+                        "element": "extensionElement",
+                        "dataType": "string",
+                        "namespace": "https://example.com",
+                        "localName": "Lot_Number",
+                        "text": "122333",
+                        "complex": null,
+                        "ID": 1
+                    }
+                ],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 3,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-16T10:00",
+                    "fromTime": "2023-03-07T16:45:36.000",
+                    "toTime": "2023-03-08T16:45:36.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "1988979798797",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": null,
+                "bizLocation": {
+                    "gcpLength": null
+                },
+                "businessStep": "SHIPPING",
+                "disposition": "IN_TRANSIT",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:45:36.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:45:36.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:45:36.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        },
+        {
+            "eventId": 5,
+            "eventType": "ObjectEvent",
+            "eventInfo": {
+                "eventCount": 1,
+                "identifierSyntax": "URN",
+                "vocabularySyntax": "URN",
+                "eventType": "ObjectEvent",
+                "importEvent": false,
+                "ordinaryEvent": true,
+                "eventTimeSelector": "SpecificTime",
+                "eventTime": {
+                    "specificTime": "2022-07-25T10:00",
+                    "fromTime": "2023-03-07T16:50:17.000",
+                    "toTime": "2023-03-08T16:50:17.000",
+                    "timeZoneOffset": "-05:00"
+                },
+                "RecordTimeOption": "no",
+                "recordTimeType": "SAME_AS_EVENT_TIME",
+                "readpointselector": "SGLN",
+                "readPoint": {
+                    "gcpLength": 7,
+                    "gln": "8763868736184",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businesslocationselector": "SGLN",
+                "bizLocation": {
+                    "gcpLength": 7,
+                    "gln": "1981981987198",
+                    "extensionType": "dynamic",
+                    "extensionFrom": "1",
+                    "extensionFormat": "5"
+                },
+                "businessStep": "RECEIVING",
+                "disposition": "IN_PROGRESS",
+                "sources": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "destinations": {
+                    "type": null,
+                    "glnType": "SGLN",
+                    "gcpLength": null
+                },
+                "eventID": false,
+                "eventIdType": "UUID",
+                "hashAlgorithm": "sha-256",
+                "action": "OBSERVE",
+                "error": {
+                    "ErrorTimeZone": "+02:00",
+                    "ErrorDeclarationTimeSelector": "SpecificTime",
+                    "ErrorReasonType": null,
+                    "errorCorrectiveIdsList": [],
+                    "errorCorrectiveCount": 0,
+                    "ErrorDeclarationTime": "2023-03-08T16:50:17.000",
+                    "ErrorDeclarationTimeFrom": "2023-03-07T16:50:17.000",
+                    "ErrorDeclarationTimeTo": "2023-03-08T16:50:17.000",
+                    "errorExtensions": []
+                },
+                "persistentDispositionCount": 0,
+                "persistentDispositionList": [],
+                "bizTransactionCount": 0,
+                "businessTransactionList": [],
+                "sensorElementList": [],
+                "referencedIdentifier": [],
+                "outputReferencedIdentifier": [],
+                "parentReferencedIdentifier": {},
+                "userExtensions": [],
+                "ilmd": [],
+                "parentID": "",
+                "epcList": [],
+                "quantityList": [],
+                "outputEPCList": [],
+                "outputQuantityList": []
+            }
+        }
+    ],
+    "identifiersNodeInfo": [
+        {
+            "identifiersId": 6,
+            "identifierSyntax": "URN",
+            "instanceData": {
+                "identifierType": "sgtin",
+                "gcpLength": 7,
+                "sgtin": "23422131231232",
+                "serialType": "range",
+                "rangeFrom": 101
+            }
+        }
+    ],
+    "connectorsInfo": [
+        {
+            "ID": 2,
+            "name": "connector2",
+            "source": "2",
+            "target": "3",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 4,
+            "name": "connector4",
+            "source": "3",
+            "target": "5",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        },
+        {
+            "ID": 5,
+            "name": "connector5",
+            "source": "6",
+            "target": "2",
+            "hideInheritParentCount": false,
+            "epcCount": 1,
+            "inheritParentCount": 0,
+            "classCount": 0,
+            "quantity": 0
+        }
+    ],
+    "drawflowInfo": {
+        "drawflow": {
+            "Home": {
+                "data": {
+                    "2": {
+                        "id": 2,
+                        "name": "Events",
+                        "data": {
+                            "ID": 2,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "6",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 267,
+                        "pos_y": 101
+                    },
+                    "3": {
+                        "id": 3,
+                        "name": "Events",
+                        "data": {
+                            "ID": 3,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "5",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 560,
+                        "pos_y": 54
+                    },
+                    "5": {
+                        "id": 5,
+                        "name": "Events",
+                        "data": {
+                            "ID": 5,
+                            "eventType": "ObjectEvent"
+                        },
+                        "class": "ObjectEvent",
+                        "html": "Events",
+                        "typenode": "vue",
+                        "inputs": {
+                            "input_1": {
+                                "connections": [
+                                    {
+                                        "node": "3",
+                                        "input": "output_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "outputs": {
+                            "output_1": {
+                                "connections": []
+                            }
+                        },
+                        "pos_x": 833,
+                        "pos_y": 120
+                    },
+                    "6": {
+                        "id": 6,
+                        "name": "Identifiers",
+                        "data": {
+                            "ID": 6,
+                            "eventType": "Identifiers"
+                        },
+                        "class": "Identifiers",
+                        "html": "Identifiers",
+                        "typenode": "vue",
+                        "inputs": {},
+                        "outputs": {
+                            "output_1": {
+                                "connections": [
+                                    {
+                                        "node": "2",
+                                        "output": "input_1"
+                                    }
+                                ]
+                            }
+                        },
+                        "pos_x": 34,
+                        "pos_y": 22
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/Design Template for GS1 Implementation Guideline examples/README.md
+++ b/examples/Design Template for GS1 Implementation Guideline examples/README.md
@@ -1,0 +1,22 @@
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+# Design template based on GS1 EPCIS implementations guideline scenarios
+
+The GS1 EPCIS standard implementation guideline (https://ref.gs1.org/guidelines/epcis-cbv/2.0.0/) offers a comprehensive set of examples that showcase different supply chain system scenarios within the EPCIS standard. Our aim is to showcase the 
+ease with which these scenarios or any other desired scenarios, can be replicated using the OpenEPCIS Test Data Generator. Also, if necessary, we can generate a large volume of EPCIS events that can be utilized across diverse scenarios.
+
+This folder comprises a range of designs for the OpenEPCIS Test Data Generator, which can be seamlessly imported into the application by executing the following:
+
+```link
+https://test-data-generator.openepcis.io/ui/DesignTestData/?url={url}
+```
+
+In the above provided link replace the `{url}` with the actual URL of the design template. Kindly note that when providing the URL, ensure that it is the raw GitHub link for accurate functionality.
+Following is the example for the demonstration purpose:
+
+```link
+https://test-data-generator.openepcis.io/ui/DesignTestData/?url=https://raw.githubusercontent.com/openepcis/epcis-testdata-generator/main/examples/design%20test%20data%20ui/Exported%20Design.json
+```
+
+Each of the example file name contains the section/table number which corresponds to respective section/table within the GS1 EPCIS standard implementation guideline (https://ref.gs1.
+org/guidelines/epcis-cbv/2.0.0/).


### PR DESCRIPTION
@sboeckelmann As discussed I have added all the Test Data Generator design templates based on GS1 implementation guidelines created by @ShaikDayan to our project. Using this we can directly access the Test Data Generator Design page for any of the examples and import the design directly. 

I kindly request you to review the changes and approve the PR.