### PR TITLE
Test Data Generator: Support custom domain URL during the DL identifiers generation.

### DIFF
--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/DestinationFormatter.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/DestinationFormatter.java
@@ -27,11 +27,11 @@ import org.krysalis.barcode4j.impl.upcean.UPCEANLogicImpl;
 public class DestinationFormatter {
 
   public static DestinationList format(
-      IdentifierVocabularyType syntax, SourceDestinationSyntax destination) {
+      IdentifierVocabularyType syntax, SourceDestinationSyntax destination, final String dlURL) {
     // If the source is Not other type then based on provided values generate the Source/Destination
     if (!destination.getType().toString().equalsIgnoreCase("other")) {
       if (IdentifierVocabularyType.WEBURI == syntax) {
-        return formatWebURI(destination);
+        return formatWebURI(destination, dlURL);
       } else {
         return formatURN(destination);
       }
@@ -71,7 +71,7 @@ public class DestinationFormatter {
     }
   }
 
-  private static DestinationList formatWebURI(SourceDestinationSyntax input) {
+  private static DestinationList formatWebURI(SourceDestinationSyntax input, final String dlURL) {
     try {
 
       String gln = input.getGln();
@@ -81,10 +81,10 @@ public class DestinationFormatter {
       // For ProcessingParty and OwningParty add the 417 as application identifier.
       if (input.getType().equals(SourceDestinationType.POSSESSING_PARTY)
           || input.getType().equals(SourceDestinationType.OWNING_PARTY)) {
-        destination = DomainName.IDENTIFIER_DOMAIN + "/417/" + gln;
+        destination = dlURL + "/417/" + gln;
       } else if (input.getType().equals(SourceDestinationType.LOCATION)) {
         // For Location add the 414 as application identifier.
-        destination = DomainName.IDENTIFIER_DOMAIN + "/414/" + gln;
+        destination = dlURL + "/414/" + gln;
       }
 
       // If the extension is present then add the extension to the destination else keep it blank.

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/ErrorDeclarationFormatter.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/ErrorDeclarationFormatter.java
@@ -15,7 +15,6 @@
  */
 package io.openepcis.testdata.generator.format;
 
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
@@ -27,9 +26,9 @@ import lombok.NoArgsConstructor;
 @RegisterForReflection
 public class ErrorDeclarationFormatter {
 
-  public static List<String> format(IdentifierVocabularyType syntax, List<String> input) {
+  public static List<String> format(IdentifierVocabularyType syntax, List<String> input, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
-      return formatWebURI(input);
+      return formatWebURI(input, dlURL);
     } else {
       return formatURN(input);
     }
@@ -39,10 +38,10 @@ public class ErrorDeclarationFormatter {
     return input.stream().filter(Objects::nonNull).toList();
   }
 
-  private static List<String> formatWebURI(List<String> input) {
+  private static List<String> formatWebURI(List<String> input, final String dlURL) {
     return input.stream()
         .filter(Objects::nonNull)
-        .map(i -> DomainName.VOCABULARY_DOMAIN + "/voc/ER-" + i)
+        .map(i -> dlURL + "/voc/ER-" + i)
         .toList();
   }
 }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/ReadpointBusinessLocationFormatter.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/ReadpointBusinessLocationFormatter.java
@@ -32,16 +32,15 @@ import org.krysalis.barcode4j.impl.upcean.UPCEANLogicImpl;
 public class ReadpointBusinessLocationFormatter {
 
   private static final String URN_PREFIX = "urn:epc:id:sgln:";
-  private static final String WEBURI_PREFIX = "https://id.gs1.org/414/";
 
-  public static String format(final IdentifierVocabularyType syntax, final ReadPointBizLocationSyntax input) {
+  public static String format(final IdentifierVocabularyType syntax, final ReadPointBizLocationSyntax input, final String dlURL) {
     // If ReadPoint/BizLocation is provided using ManualURI then return the same
     if (input.getType() != null && input.getType().equals(ReadPointBizLocationType.MANUALLY) && input.getManualURI() != null) {
       return input.getManualURI();
     } else if(input.getType() != null && input.getType().equals(ReadPointBizLocationType.SGLN)) {
       // If ReadPoint/BizLocation is provided as an CBV based values then format them accordingly
       if (IdentifierVocabularyType.WEBURI == syntax) {
-        return formatWebURI(input);
+        return formatWebURI(input, dlURL);
       } else {
         return formatURN(input);
       }
@@ -67,7 +66,9 @@ public class ReadpointBusinessLocationFormatter {
     }
   }
 
-  private static String formatWebURI(final ReadPointBizLocationSyntax input) {
+  private static String formatWebURI(final ReadPointBizLocationSyntax input, final String dlURL) {
+    final String WEBURI_PREFIX = dlURL + "/414/";
+
     try {
       String gln = input.getGln();
       gln = gln.substring(0, 12) + UPCEANLogicImpl.calcChecksum(gln.substring(0, 12));

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/SourceFormatter.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/format/SourceFormatter.java
@@ -24,11 +24,11 @@ import org.krysalis.barcode4j.impl.upcean.UPCEANLogicImpl;
 @RegisterForReflection
 public class SourceFormatter implements Serializable {
 
-  public static SourceList format(IdentifierVocabularyType syntax, SourceDestinationSyntax source) {
+  public static SourceList format(IdentifierVocabularyType syntax, SourceDestinationSyntax source, final String dlURL) {
     // If the source is Not other type then based on provided values generate the Source/Destination
     if (!source.getType().toString().equalsIgnoreCase("other")) {
       if (IdentifierVocabularyType.WEBURI == syntax) {
-        return formatWebURI(source);
+        return formatWebURI(source, dlURL);
       } else {
         return formatURN(source);
       }
@@ -67,7 +67,7 @@ public class SourceFormatter implements Serializable {
     }
   }
 
-  private static SourceList formatWebURI(SourceDestinationSyntax input) {
+  private static SourceList formatWebURI(SourceDestinationSyntax input, final String dlURL) {
     try {
       String gln = input.getGln();
       gln = gln.substring(0, 12) + UPCEANLogicImpl.calcChecksum(gln.substring(0, 12));
@@ -76,10 +76,10 @@ public class SourceFormatter implements Serializable {
       // For ProcessingParty and OwningParty add the 417 as application identifier.
       if (input.getType().equals(SourceDestinationType.POSSESSING_PARTY)
           || input.getType().equals(SourceDestinationType.OWNING_PARTY)) {
-        source = DomainName.IDENTIFIER_DOMAIN + "/417/" + gln;
+        source = dlURL + "/417/" + gln;
       } else if (input.getType().equals(SourceDestinationType.LOCATION)) {
         // For Location add the 414 as application identifier.
-        source = DomainName.IDENTIFIER_DOMAIN + "/414/" + gln;
+        source = dlURL + "/414/" + gln;
       }
 
       // If the extension is present then add the extension to the source else keep it blank.

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateCPI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateCPI.java
@@ -45,14 +45,14 @@ public class GenerateCPI extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateCpiIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateCpiIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate CPI Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateCpiIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -68,7 +68,7 @@ public class GenerateCPI extends GenerateQuantity {
             quantityFormatted.setEpcClass(CPI_URN_PART + modifiedUrnCPI + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(DomainName.IDENTIFIER_DOMAIN + "/8010/" + cpi);
+            quantityFormatted.setEpcClass(dlURL + "/8010/" + cpi);
           }
 
           // Add the quantity and UOM information if provided accordingly to the Quantity

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGCN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGCN.java
@@ -47,14 +47,14 @@ public class GenerateGCN extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateGcnIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateGcnIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate GCN Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateGcnIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -75,7 +75,7 @@ public class GenerateGCN extends GenerateQuantity {
             quantityFormatted.setEpcClass(SGCN_URN_PART + modifiedUrnGCN + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(DomainName.IDENTIFIER_DOMAIN + "/255/" + modifiedUriGCN);
+            quantityFormatted.setEpcClass(dlURL + "/255/" + modifiedUriGCN);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGDTI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGDTI.java
@@ -48,14 +48,14 @@ public class GenerateGDTI extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateGdtiIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateGdtiIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate GDTI Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateGdtiIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -76,8 +76,7 @@ public class GenerateGDTI extends GenerateQuantity {
             quantityFormatted.setEpcClass(GDTI_URN_PART + modifiedUrnGDTI + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(
-                DomainName.IDENTIFIER_DOMAIN + GDTI_URI_PART + modifiedUriGDTI);
+            quantityFormatted.setEpcClass(dlURL + GDTI_URI_PART + modifiedUriGDTI);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGRAI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGRAI.java
@@ -48,14 +48,14 @@ public class GenerateGRAI extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateGraiIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateGraiIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate GRAI Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateGraiIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -76,8 +76,7 @@ public class GenerateGRAI extends GenerateQuantity {
             quantityFormatted.setEpcClass(GRAI_URN_PART + modifiedUrnGRAI + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(
-                DomainName.IDENTIFIER_DOMAIN + GRAI_URI_PART + modifiedUriGRAI);
+            quantityFormatted.setEpcClass(dlURL + GRAI_URI_PART + modifiedUriGRAI);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGTIN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateGTIN.java
@@ -48,14 +48,14 @@ public class GenerateGTIN extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateGtinIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateGtinIdentifiers(syntax, count, refQuantity,dlURL);
   }
 
   // Method to generate GTIN Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateGtinIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -76,8 +76,7 @@ public class GenerateGTIN extends GenerateQuantity {
             quantityFormatted.setEpcClass(GTIN_URN_PART + modifiedUrnGRAI + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(
-                DomainName.IDENTIFIER_DOMAIN + GTIN_URI_PART + modifiedUriGRAI);
+            quantityFormatted.setEpcClass(dlURL + GTIN_URI_PART + modifiedUriGRAI);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateITIP.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateITIP.java
@@ -46,14 +46,14 @@ public class GenerateITIP extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateItipIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateItipIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate ITIP Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateItipIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -85,8 +85,7 @@ public class GenerateITIP extends GenerateQuantity {
             quantityFormatted.setEpcClass(ITIP_URN_PART + modifiedUrnITIP + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(
-                DomainName.IDENTIFIER_DOMAIN + ITIP_URI_PART + itip + modifiedUriITIP);
+            quantityFormatted.setEpcClass(dlURL + ITIP_URI_PART + itip + modifiedUriITIP);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateLGTIN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateLGTIN.java
@@ -32,6 +32,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Setter;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.krysalis.barcode4j.impl.upcean.UPCEANLogicImpl;
@@ -71,11 +72,11 @@ public class GenerateLGTIN extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Class Identifiers
-      return generateWebURI(count, refQuantity);
+      return generateWebURI(count, refQuantity, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Class
       // Identifiers
@@ -145,13 +146,12 @@ public class GenerateLGTIN extends GenerateQuantity {
     }
   }
 
-  public List<QuantityList> generateWebURI(Integer count, final Float refQuantity) {
+  public List<QuantityList> generateWebURI(Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final String formattedLgtin =
           this.lgtin.substring(0, 13) + UPCEANLogicImpl.calcChecksum(this.lgtin.substring(0, 13));
-      final String lgtinWebURI =
-          DomainName.IDENTIFIER_DOMAIN + LGTIN_URI_PART + formattedLgtin + LGTIN_SERIAL_PART;
+      final String lgtinWebURI = dlURL + LGTIN_URI_PART + formattedLgtin + LGTIN_SERIAL_PART;
       quantity = refQuantity != null && refQuantity != 0 ? refQuantity : quantity;
 
       // Return the list of SGTIN for RANGE calculation
@@ -222,8 +222,10 @@ public class GenerateLGTIN extends GenerateQuantity {
         syntax.equals(IdentifierVocabularyType.URN)
             ? LGTIN_URN_PART + formattedLgtin + "." + serialId
             : formattedLgtin + serialId);
-    quantityFormatted.setQuantity(quantity);
-    quantityFormatted.setUom(uom);
+    if(!StringUtils.isBlank(quantityType)){
+      quantityFormatted.setQuantity(quantity);
+      quantityFormatted.setUom(uom);
+    }
     return quantityFormatted;
   }
 }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateManualURI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateManualURI.java
@@ -59,11 +59,11 @@ public class GenerateManualURI implements QuantityStatergy {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateManualURI(refQuantity, count);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateManualURI(refQuantity, count, dlURL);
   }
 
-  private List<QuantityList> generateManualURI(final Float refQuantity, final Integer count) {
+  private List<QuantityList> generateManualURI(final Float refQuantity, final Integer count, final String dlURL) {
     try {
       final List<QuantityList> formattedURI = new ArrayList<>();
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateQuantity.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateQuantity.java
@@ -32,6 +32,8 @@ public abstract class GenerateQuantity implements QuantityStatergy {
   @Max(value = 12, message = "Class Identifiers GCP Length cannot be more than 12")
   protected Integer gcpLength = 6;
 
+  protected String quantityType;
+
   protected Float quantity;
 
   protected String uom;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateUPUI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/GenerateUPUI.java
@@ -48,14 +48,14 @@ public class GenerateUPUI extends GenerateQuantity {
 
   @Override
   public List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
-    return generateUpuiIdentifiers(syntax, count, refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
+    return generateUpuiIdentifiers(syntax, count, refQuantity, dlURL);
   }
 
   // Method to generate UPUI Class identifiers in URN/WebURI format based on information provided by
   // the users.
   private List<QuantityList> generateUpuiIdentifiers(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity) {
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL) {
     try {
       final List<QuantityList> returnQuantityFormatted = new ArrayList<>();
       final var quantityFormatted = new QuantityList();
@@ -81,8 +81,7 @@ public class GenerateUPUI extends GenerateQuantity {
             quantityFormatted.setEpcClass(UPUI_URN_PART + formattedUrnUPUI + ".*");
           } else if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
             // For WebURI syntax create the identifiers based on the WebURI type
-            quantityFormatted.setEpcClass(
-                DomainName.IDENTIFIER_DOMAIN + UPUI_URI_PART + formattedUriUPUI);
+            quantityFormatted.setEpcClass(dlURL + UPUI_URI_PART + formattedUriUPUI);
           }
           quantityFormatted.setQuantity(
               refQuantity != null && refQuantity != 0 ? refQuantity : quantity);

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/QuantityStatergy.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/classes/QuantityStatergy.java
@@ -37,5 +37,5 @@ import java.util.List;
 @RegisterForReflection
 public interface QuantityStatergy {
   List<QuantityList> format(
-      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity);
+      final IdentifierVocabularyType syntax, final Integer count, final Float refQuantity, final String dlURL);
 }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/EPCStrategy.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/EPCStrategy.java
@@ -45,5 +45,5 @@ import java.util.List;
 })
 @RegisterForReflection
 public interface EPCStrategy {
-  List<String> format(IdentifierVocabularyType syntax, Integer count);
+  List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL);
 }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateADI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateADI.java
@@ -96,7 +96,7 @@ public class GenerateADI implements EPCStrategy {
   private static final String ADI_URN_PART = "urn:epc:id:adi:";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     return generateURN(count);
   }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateBIC.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateBIC.java
@@ -41,7 +41,7 @@ public class GenerateBIC implements EPCStrategy {
   private String bic;
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     return generateBIC();
   }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateCPI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateCPI.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -48,11 +47,11 @@ public class GenerateCPI extends GenerateEPC {
   private static final String SERIAL_URI_PART = "/8011/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -103,7 +102,7 @@ public class GenerateCPI extends GenerateEPC {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedCPI = new ArrayList<>();
 
@@ -116,8 +115,7 @@ public class GenerateCPI extends GenerateEPC {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count.longValue();
             rangeID++) {
-          formattedCPI.add(
-              DomainName.IDENTIFIER_DOMAIN + CPI_URI_PART + cpi + SERIAL_URI_PART + rangeID);
+          formattedCPI.add(dlURL + CPI_URI_PART + cpi + SERIAL_URI_PART + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count.longValue());
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -130,14 +128,12 @@ public class GenerateCPI extends GenerateEPC {
                 randomType, randomMinLength, randomMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedCPI.add(
-              DomainName.IDENTIFIER_DOMAIN + CPI_URI_PART + cpi + SERIAL_URI_PART + randomID);
+          formattedCPI.add(dlURL + CPI_URI_PART + cpi + SERIAL_URI_PART + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         // Return the single CPI values for None selection
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedCPI.add(
-              DomainName.IDENTIFIER_DOMAIN + CPI_URI_PART + cpi + SERIAL_URI_PART + serialNumber);
+          formattedCPI.add(dlURL + CPI_URI_PART + cpi + SERIAL_URI_PART + serialNumber);
         }
       }
       return formattedCPI;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGCN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGCN.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -39,11 +38,11 @@ public class GenerateGCN extends GenerateEPCType2 {
   private static final String URI_SGCN_PART = "/255/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -97,7 +96,7 @@ public class GenerateGCN extends GenerateEPCType2 {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       List<String> formattedGCN = new ArrayList<>();
 
@@ -111,7 +110,7 @@ public class GenerateGCN extends GenerateEPCType2 {
             rangeID++) {
           var append = gcp + rangeID;
           append = StringUtils.repeat("0", 23 - append.length()) + rangeID;
-          formattedGCN.add(DomainName.IDENTIFIER_DOMAIN + URI_SGCN_PART + gcp + append);
+          formattedGCN.add(dlURL + URI_SGCN_PART + gcp + append);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -120,11 +119,11 @@ public class GenerateGCN extends GenerateEPCType2 {
             RandomValueGenerator.randomGenerator(
                 RandomizationType.NUMERIC, requiredLength, requiredLength, count);
         for (var randomID : randomSerialNumbers) {
-          formattedGCN.add(DomainName.IDENTIFIER_DOMAIN + URI_SGCN_PART + gcp + randomID);
+          formattedGCN.add(dlURL + URI_SGCN_PART + gcp + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedGCN.add(DomainName.IDENTIFIER_DOMAIN + URI_SGCN_PART + gcp + serialNumber);
+          formattedGCN.add(dlURL + URI_SGCN_PART + gcp + serialNumber);
         }
       }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGDTI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGDTI.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
 import io.openepcis.testdata.generator.format.CompanyPrefixFormatter;
@@ -48,11 +47,11 @@ public class GenerateGDTI extends GenerateEPC {
   private String gdti;
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -105,7 +104,7 @@ public class GenerateGDTI extends GenerateEPC {
   }
 
   // Generate URN formatted GDTI
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGDTI = new ArrayList<>();
       final String modifiedGDTI =
@@ -122,7 +121,7 @@ public class GenerateGDTI extends GenerateEPC {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count;
             rangeID++) {
-          formattedGDTI.add(DomainName.IDENTIFIER_DOMAIN + GDTI_URI_PART + modifiedGDTI + rangeID);
+          formattedGDTI.add(dlURL + GDTI_URI_PART + modifiedGDTI + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -135,13 +134,12 @@ public class GenerateGDTI extends GenerateEPC {
                 randomType, randomMinLength, randomMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedGDTI.add(DomainName.IDENTIFIER_DOMAIN + GDTI_URI_PART + modifiedGDTI + randomID);
+          formattedGDTI.add(dlURL + GDTI_URI_PART + modifiedGDTI + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         // Return the single GDTI values for None selection
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedGDTI.add(
-              DomainName.IDENTIFIER_DOMAIN + GDTI_URI_PART + modifiedGDTI + serialNumber);
+          formattedGDTI.add(dlURL + GDTI_URI_PART + modifiedGDTI + serialNumber);
         }
       }
       return formattedGDTI;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGIAI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGIAI.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -38,11 +37,11 @@ public class GenerateGIAI extends GenerateEPCType2 {
   private static final String GIAI_URI_PART = "/8004/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -92,7 +91,7 @@ public class GenerateGIAI extends GenerateEPCType2 {
   }
 
   // Generate URN formatted GIAI
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGIAI = new ArrayList<>();
 
@@ -105,7 +104,7 @@ public class GenerateGIAI extends GenerateEPCType2 {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count.longValue();
             rangeID++) {
-          formattedGIAI.add(DomainName.IDENTIFIER_DOMAIN + GIAI_URI_PART + gcp + rangeID);
+          formattedGIAI.add(dlURL + GIAI_URI_PART + gcp + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count.longValue());
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -116,12 +115,12 @@ public class GenerateGIAI extends GenerateEPCType2 {
                 RandomizationType.NUMERIC, 1, requiredMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedGIAI.add(DomainName.IDENTIFIER_DOMAIN + GIAI_URI_PART + gcp + randomID);
+          formattedGIAI.add(dlURL + GIAI_URI_PART + gcp + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         // Return the single GIAI values for None selection
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedGIAI.add(DomainName.IDENTIFIER_DOMAIN + GIAI_URI_PART + gcp + serialNumber);
+          formattedGIAI.add(dlURL + GIAI_URI_PART + gcp + serialNumber);
         }
       }
       return formattedGIAI;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGID.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGID.java
@@ -88,7 +88,7 @@ public class GenerateGID implements EPCStrategy {
   private static final String GID_URN_PART = "urn:epc:id:gid:";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (manager != null && gidClass != null) {
       return generateURN(count);
     }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGINC.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGINC.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -38,11 +37,11 @@ public class GenerateGINC extends GenerateEPCType2 {
   private static final String GINC_URI_PART = "/401/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -90,7 +89,7 @@ public class GenerateGINC extends GenerateEPCType2 {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGINC = new ArrayList<>();
 
@@ -103,7 +102,7 @@ public class GenerateGINC extends GenerateEPCType2 {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count;
             rangeID++) {
-          formattedGINC.add(DomainName.IDENTIFIER_DOMAIN + GINC_URI_PART + gcp + rangeID);
+          formattedGINC.add(dlURL + GINC_URI_PART + gcp + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -114,12 +113,12 @@ public class GenerateGINC extends GenerateEPCType2 {
                 RandomizationType.NUMERIC, 1, requiredMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedGINC.add(DomainName.IDENTIFIER_DOMAIN + GINC_URI_PART + gcp + randomID);
+          formattedGINC.add(dlURL + GINC_URI_PART + gcp + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         // None selection
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedGINC.add(DomainName.IDENTIFIER_DOMAIN + GINC_URI_PART + gcp + serialNumber);
+          formattedGINC.add(dlURL + GINC_URI_PART + gcp + serialNumber);
         }
       }
       return formattedGINC;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGRAI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGRAI.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
 import io.openepcis.testdata.generator.format.CompanyPrefixFormatter;
@@ -48,11 +47,11 @@ public class GenerateGRAI extends GenerateEPC {
   private static final String GRAI_URI_PART = "/8003/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -103,7 +102,7 @@ public class GenerateGRAI extends GenerateEPC {
   }
 
   // Generate WebURI formatted GRAI
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGRAI = new ArrayList<>();
       final String modifiedGRAI =
@@ -118,7 +117,7 @@ public class GenerateGRAI extends GenerateEPC {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count;
             rangeID++) {
-          formattedGRAI.add(DomainName.IDENTIFIER_DOMAIN + GRAI_URI_PART + modifiedGRAI + rangeID);
+          formattedGRAI.add(dlURL + GRAI_URI_PART + modifiedGRAI + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -131,12 +130,11 @@ public class GenerateGRAI extends GenerateEPC {
                 randomType, randomMinLength, randomMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedGRAI.add(DomainName.IDENTIFIER_DOMAIN + GRAI_URI_PART + modifiedGRAI + randomID);
+          formattedGRAI.add(dlURL + GRAI_URI_PART + modifiedGRAI + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null) {
         // Return the single GRAI values for None selection
-        formattedGRAI.add(
-            DomainName.IDENTIFIER_DOMAIN + GRAI_URI_PART + modifiedGRAI + serialNumber);
+        formattedGRAI.add(dlURL + GRAI_URI_PART + modifiedGRAI + serialNumber);
       }
       return formattedGRAI;
     } catch (Exception ex) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSIN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSIN.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -39,11 +38,11 @@ public class GenerateGSIN extends GenerateEPCType2 {
   private static final String GSIN_URI_PART = "/402/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -94,7 +93,7 @@ public class GenerateGSIN extends GenerateEPCType2 {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGSIN = new ArrayList<>();
 
@@ -109,7 +108,7 @@ public class GenerateGSIN extends GenerateEPCType2 {
             rangeID++) {
           var append = gcp + rangeID;
           append = StringUtils.repeat("0", 17 - append.length()) + rangeID;
-          formattedGSIN.add(DomainName.IDENTIFIER_DOMAIN + GSIN_URI_PART + gcp + append);
+          formattedGSIN.add(dlURL + GSIN_URI_PART + gcp + append);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count.longValue());
       } else if (serialType.equalsIgnoreCase("random") && count != null && count.longValue() > 0) {
@@ -120,14 +119,14 @@ public class GenerateGSIN extends GenerateEPCType2 {
         for (var randomID : randomSerialNumbers) {
           var append = gcp + randomID;
           append = StringUtils.repeat("0", 17 - append.length()) + randomID;
-          formattedGSIN.add(DomainName.IDENTIFIER_DOMAIN + GSIN_URI_PART + gcp + append);
+          formattedGSIN.add(dlURL + GSIN_URI_PART + gcp + append);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         // None selection
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
           var append = gcp + serialNumber;
           append = StringUtils.repeat("0", 17 - append.length()) + serialNumber;
-          formattedGSIN.add(DomainName.IDENTIFIER_DOMAIN + GSIN_URI_PART + gcp + append);
+          formattedGSIN.add(dlURL + GSIN_URI_PART + gcp + append);
         }
       }
       return formattedGSIN;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSRN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSRN.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -39,11 +38,11 @@ public class GenerateGSRN extends GenerateEPCType2 {
   private static final String GSRN_URI_PART = "/8018/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -94,7 +93,7 @@ public class GenerateGSRN extends GenerateEPCType2 {
   }
 
   // Generate GSRN based on the WebURI Format
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGSRN = new ArrayList<>();
       if (rangeFrom != null && count != null && count > 0 && rangeFrom.longValue() >= 0) {
@@ -103,7 +102,7 @@ public class GenerateGSRN extends GenerateEPCType2 {
             rangeID++) {
           var append = gcp + rangeID;
           append = StringUtils.repeat("0", 18 - append.length()) + rangeID;
-          formattedGSRN.add(DomainName.IDENTIFIER_DOMAIN + GSRN_URI_PART + gcp + append);
+          formattedGSRN.add(dlURL + GSRN_URI_PART + gcp + append);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -112,7 +111,7 @@ public class GenerateGSRN extends GenerateEPCType2 {
             RandomValueGenerator.randomGenerator(
                 RandomizationType.NUMERIC, requiredLength, requiredLength, count);
         for (var randomID : randomSerialNumbers) {
-          formattedGSRN.add(DomainName.IDENTIFIER_DOMAIN + GSRN_URI_PART + gcp + randomID);
+          formattedGSRN.add(dlURL + GSRN_URI_PART + gcp + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none")
           && serialNumber != null
@@ -122,7 +121,7 @@ public class GenerateGSRN extends GenerateEPCType2 {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
           var append = gcp + serialNumber;
           append = StringUtils.repeat("0", 18 - append.length()) + serialNumber;
-          formattedGSRN.add(DomainName.IDENTIFIER_DOMAIN + GSRN_URI_PART + gcp + append);
+          formattedGSRN.add(dlURL + GSRN_URI_PART + gcp + append);
         }
       }
       return formattedGSRN;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSRNP.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateGSRNP.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -39,9 +38,9 @@ public class GenerateGSRNP extends GenerateEPCType2 {
   private static final String GSRNP_URI_PART = "/8017/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       return generateURN(count);
     }
@@ -93,7 +92,7 @@ public class GenerateGSRNP extends GenerateEPCType2 {
   }
 
   // Generate GSRN based on the WebURI Format
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedGSRNP = new ArrayList<>();
       if (serialType.equalsIgnoreCase("range")
@@ -106,7 +105,7 @@ public class GenerateGSRNP extends GenerateEPCType2 {
             rangeID++) {
           String append = gcp + rangeID;
           append = StringUtils.repeat("0", 18 - append.length()) + rangeID;
-          final String gsrnpID = DomainName.IDENTIFIER_DOMAIN + GSRNP_URI_PART + gcp + append;
+          final String gsrnpID = dlURL + GSRNP_URI_PART + gcp + append;
           formattedGSRNP.add(gsrnpID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
@@ -116,14 +115,14 @@ public class GenerateGSRNP extends GenerateEPCType2 {
             RandomValueGenerator.randomGenerator(
                 RandomizationType.NUMERIC, requiredLength, requiredLength, randomCount);
         for (var randomID : randomSerialNumbers) {
-          final String gsrnpID = DomainName.IDENTIFIER_DOMAIN + GSRNP_URI_PART + gcp + randomID;
+          final String gsrnpID = dlURL + GSRNP_URI_PART + gcp + randomID;
           formattedGSRNP.add(gsrnpID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
           String append = gcp + serialNumber;
           append = StringUtils.repeat("0", 18 - append.length()) + serialNumber;
-          final String gsrnpID = DomainName.IDENTIFIER_DOMAIN + GSRNP_URI_PART + gcp + append;
+          final String gsrnpID = dlURL + GSRNP_URI_PART + gcp + append;
           formattedGSRNP.add(gsrnpID);
         }
       }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateIMOVN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateIMOVN.java
@@ -52,7 +52,7 @@ public class GenerateIMOVN implements EPCStrategy {
   private static final String IMOVN_URN_PART = "urn:epc:id:imovn:";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     return generateIMOVN(count);
   }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateITIP.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateITIP.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
 import io.openepcis.testdata.generator.format.RandomValueGenerator;
@@ -47,9 +46,9 @@ public class GenerateITIP extends GenerateEPC {
   private static final String ITIP_SERIAL_PART = "/21/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (IdentifierVocabularyType.WEBURI == syntax) {
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       return generateURN(count);
     }
@@ -107,7 +106,7 @@ public class GenerateITIP extends GenerateEPC {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedITIP = new ArrayList<>();
       var modifiedITIP = itip.substring(0, 18);
@@ -118,15 +117,8 @@ public class GenerateITIP extends GenerateEPC {
           && count != null
           && count > 0
           && rangeFrom.longValue() >= 0) {
-        for (var rangeID = rangeFrom.longValue();
-            rangeID < rangeFrom.longValue() + count;
-            rangeID++) {
-          formattedITIP.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + ITIP_URI_PART
-                  + modifiedITIP
-                  + ITIP_SERIAL_PART
-                  + rangeID);
+        for (var rangeID = rangeFrom.longValue(); rangeID < rangeFrom.longValue() + count; rangeID++) {
+          formattedITIP.add(dlURL + ITIP_URI_PART + modifiedITIP + ITIP_SERIAL_PART + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -134,25 +126,14 @@ public class GenerateITIP extends GenerateEPC {
         randomMaxLength = randomMaxLength < 1 || randomMaxLength > 20 ? 20 : randomMaxLength;
 
         final List<String> randomSerialNumbers =
-            RandomValueGenerator.randomGenerator(
-                randomType, randomMinLength, randomMaxLength, count);
+            RandomValueGenerator.randomGenerator(randomType, randomMinLength, randomMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedITIP.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + ITIP_URI_PART
-                  + modifiedITIP
-                  + ITIP_SERIAL_PART
-                  + randomID);
+          formattedITIP.add(dlURL + ITIP_URI_PART + modifiedITIP + ITIP_SERIAL_PART + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedITIP.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + ITIP_URI_PART
-                  + modifiedITIP
-                  + ITIP_SERIAL_PART
-                  + serialNumber);
+          formattedITIP.add(dlURL + ITIP_URI_PART + modifiedITIP + ITIP_SERIAL_PART + serialNumber);
         }
       }
       return formattedITIP;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateManualURI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateManualURI.java
@@ -52,7 +52,7 @@ public class GenerateManualURI implements EPCStrategy {
   private Integer manualUriRangeTo;
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     return generateURI(count);
   }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateSGTIN.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateSGTIN.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
 import io.openepcis.testdata.generator.format.CompanyPrefixFormatter;
@@ -52,11 +51,11 @@ public class GenerateSGTIN extends GenerateEPC {
   private static final String SGTIN_URI_SERIAL_PART = "/21/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -113,7 +112,7 @@ public class GenerateSGTIN extends GenerateEPC {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedSGTIN = new ArrayList<>();
       sgtin =
@@ -129,7 +128,7 @@ public class GenerateSGTIN extends GenerateEPC {
             rangeID < rangeFrom.longValue() + count;
             rangeID++) {
           formattedSGTIN.add(
-              DomainName.IDENTIFIER_DOMAIN
+                  dlURL
                   + SGTIN_URI_PART
                   + sgtin
                   + SGTIN_URI_SERIAL_PART
@@ -146,7 +145,7 @@ public class GenerateSGTIN extends GenerateEPC {
 
         for (var randomID : randomSerialNumbers) {
           formattedSGTIN.add(
-              DomainName.IDENTIFIER_DOMAIN
+                  dlURL
                   + SGTIN_URI_PART
                   + sgtin
                   + SGTIN_URI_SERIAL_PART
@@ -158,7 +157,7 @@ public class GenerateSGTIN extends GenerateEPC {
           && count > 0) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
           formattedSGTIN.add(
-              DomainName.IDENTIFIER_DOMAIN
+                  dlURL
                   + SGTIN_URI_PART
                   + sgtin
                   + SGTIN_URI_SERIAL_PART

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateSSCC.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateSSCC.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.RandomizationType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
@@ -39,11 +38,11 @@ public class GenerateSSCC extends GenerateEPCType2 {
   private static final String SSCC_URI_PART = "/00/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -92,7 +91,7 @@ public class GenerateSSCC extends GenerateEPCType2 {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedSSCC = new ArrayList<>();
 
@@ -106,7 +105,7 @@ public class GenerateSSCC extends GenerateEPCType2 {
             rangeID++) {
           var append = gcp + rangeID;
           append = StringUtils.repeat("0", 18 - append.length()) + rangeID;
-          formattedSSCC.add(DomainName.IDENTIFIER_DOMAIN + SSCC_URI_PART + gcp + append);
+          formattedSSCC.add(dlURL + SSCC_URI_PART + gcp + append);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
@@ -116,13 +115,13 @@ public class GenerateSSCC extends GenerateEPCType2 {
                 RandomizationType.NUMERIC, requiredLength, requiredLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedSSCC.add(DomainName.IDENTIFIER_DOMAIN + SSCC_URI_PART + gcp + randomID);
+          formattedSSCC.add(dlURL + SSCC_URI_PART + gcp + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null && count != null) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
           var append = gcp + serialNumber;
           append = StringUtils.repeat("0", 17 - append.length()) + serialNumber;
-          formattedSSCC.add(DomainName.IDENTIFIER_DOMAIN + SSCC_URI_PART + gcp + append);
+          formattedSSCC.add(dlURL + SSCC_URI_PART + gcp + append);
         }
       }
       return formattedSSCC;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateUPUI.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateUPUI.java
@@ -16,7 +16,6 @@
 package io.openepcis.testdata.generator.identifier.instances;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.constants.TestDataGeneratorException;
 import io.openepcis.testdata.generator.format.CompanyPrefixFormatter;
@@ -49,11 +48,11 @@ public class GenerateUPUI extends GenerateEPC {
   private static final String UPUI_URI_SERIAL_PART = "/235/";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     if (syntax.equals(IdentifierVocabularyType.WEBURI)) {
       // For WebURI syntax call the generateWebURI, pass the required identifiers count to create
       // Instance Identifiers
-      return generateWebURI(count);
+      return generateWebURI(count, dlURL);
     } else {
       // For URN syntax call the generateURN, pass the required identifiers count to create Instance
       // Identifiers
@@ -104,7 +103,7 @@ public class GenerateUPUI extends GenerateEPC {
     }
   }
 
-  private List<String> generateWebURI(Integer count) {
+  private List<String> generateWebURI(Integer count, final String dlURL) {
     try {
       final List<String> formattedUPUI = new ArrayList<>();
       final String modifiedUPUI =
@@ -119,38 +118,21 @@ public class GenerateUPUI extends GenerateEPC {
         for (var rangeID = rangeFrom.longValue();
             rangeID < rangeFrom.longValue() + count;
             rangeID++) {
-          formattedUPUI.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + UPUI_URI_PART
-                  + modifiedUPUI
-                  + UPUI_URI_SERIAL_PART
-                  + rangeID);
+          formattedUPUI.add(dlURL + UPUI_URI_PART + modifiedUPUI + UPUI_URI_SERIAL_PART + rangeID);
         }
         this.rangeFrom = BigInteger.valueOf(this.rangeFrom.longValue() + count);
       } else if (serialType.equalsIgnoreCase("random") && count != null && count > 0) {
         randomMinLength = randomMinLength < 1 || randomMinLength > 28 ? 1 : randomMinLength;
         randomMaxLength = randomMaxLength < 1 || randomMaxLength > 28 ? 28 : randomMaxLength;
 
-        final List<String> randomSerialNumbers =
-            RandomValueGenerator.randomGenerator(
-                randomType, randomMinLength, randomMaxLength, count);
+        final List<String> randomSerialNumbers = RandomValueGenerator.randomGenerator(randomType, randomMinLength, randomMaxLength, count);
 
         for (var randomID : randomSerialNumbers) {
-          formattedUPUI.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + UPUI_URI_PART
-                  + modifiedUPUI
-                  + UPUI_URI_SERIAL_PART
-                  + randomID);
+          formattedUPUI.add(dlURL + UPUI_URI_PART + modifiedUPUI + UPUI_URI_SERIAL_PART + randomID);
         }
       } else if (serialType.equalsIgnoreCase("none") && serialNumber != null) {
         for (var noneCounter = 0; noneCounter < count; noneCounter++) {
-          formattedUPUI.add(
-              DomainName.IDENTIFIER_DOMAIN
-                  + UPUI_URI_PART
-                  + modifiedUPUI
-                  + UPUI_URI_SERIAL_PART
-                  + serialNumber);
+          formattedUPUI.add(dlURL + UPUI_URI_PART + modifiedUPUI + UPUI_URI_SERIAL_PART + serialNumber);
         }
       }
       return formattedUPUI;

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateUSDoD.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/identifier/instances/GenerateUSDoD.java
@@ -83,7 +83,7 @@ public class GenerateUSDoD implements EPCStrategy {
   private static final String USDOD_URN_PART = "urn:epc:id:usdod:";
 
   @Override
-  public List<String> format(IdentifierVocabularyType syntax, Integer count) {
+  public List<String> format(IdentifierVocabularyType syntax, Integer count, final String dlURL) {
     return generateURN(count);
   }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -269,7 +269,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
           epcList.addAll(
               matchingIdentifier
                   .getInstanceData()
-                  .format(matchingIdentifier.getObjectIdentifierSyntax(), epc.getEpcCount()));
+                  .format(matchingIdentifier.getObjectIdentifierSyntax(), epc.getEpcCount(), matchingIdentifier.getDlURL()));
         }
       } else if (epc.getParentNodeId() != 0 && epc.getEpcCount() != null && epc.getEpcCount() > 0) {
         // If referenced identifier contains the parent node id then obtain the identifiers from its
@@ -338,7 +338,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                   .format(
                       matchedClassIdentifier.getObjectIdentifierSyntax(),
                       quantity.getClassCount(),
-                      quantity.getQuantity()));
+                      quantity.getQuantity(), matchedClassIdentifier.getDlURL()));
         }
       } else if (quantity.getParentNodeId() != 0  && quantity.getClassCount() != null && quantity.getClassCount() > 0) {
         // If referenced identifier contains the parent node id then obtain the identifiers from its

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -133,7 +133,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
   private void configureWhereDimension(final E epcisEvent, final IdentifierVocabularyType syntax) {
     // Set Read Point
     if (typeInfo.getReadPoint() != null) {
-      final String formattedReadPoint = ReadpointBusinessLocationFormatter.format(syntax, typeInfo.getReadPoint());
+      final String formattedReadPoint = ReadpointBusinessLocationFormatter.format(syntax, typeInfo.getReadPoint(), typeInfo.getDlURL());
       var rp = new ReadPoint();
 
       try {
@@ -151,7 +151,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
 
     // Set Biz Location
     if (typeInfo.getBizLocation() != null) {
-      final String formattedBizLocation = ReadpointBusinessLocationFormatter.format(syntax, typeInfo.getBizLocation());
+      final String formattedBizLocation = ReadpointBusinessLocationFormatter.format(syntax, typeInfo.getBizLocation(), typeInfo.getDlURL());
       var biz = new BizLocation();
 
       try {
@@ -205,8 +205,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
       if (typeInfo.getErrorDeclaration().getCorrectiveIds() != null
           && !typeInfo.getErrorDeclaration().getCorrectiveIds().isEmpty()) {
         err.setCorrectiveEventIDs(
-            ErrorDeclarationFormatter.format(
-                syntax, typeInfo.getErrorDeclaration().getCorrectiveIds()));
+            ErrorDeclarationFormatter.format(syntax, typeInfo.getErrorDeclaration().getCorrectiveIds(), typeInfo.getDlURL()));
       }
 
       // Add Error Extensions if not null

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
@@ -73,14 +73,14 @@ public class AggregationEventCreationModel
     // Add source list
     if (typeInfo.getSources() != null && !typeInfo.getSources().isEmpty()) {
       e.setSourceList(
-          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src)).toList());
+          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src, typeInfo.getDlURL())).toList());
     }
 
     // Add Destination list
     if (typeInfo.getDestinations() != null && !typeInfo.getDestinations().isEmpty()) {
       e.setDestinationList(
           typeInfo.getDestinations().stream()
-              .map(dst -> DestinationFormatter.format(syntax, dst))
+              .map(dst -> DestinationFormatter.format(syntax, dst, typeInfo.getDlURL()))
               .toList());
     }
 
@@ -101,7 +101,7 @@ public class AggregationEventCreationModel
       e.setParentID(
               matchingParentId
                       .getParentData()
-                      .format(matchingParentId.getObjectIdentifierSyntax(), 1)
+                      .format(matchingParentId.getObjectIdentifierSyntax(), 1, matchingParentId.getDlURL())
                       .get(0));
     } else if (typeInfo.getParentIdentifier() != null && !typeInfo.getParentIdentifier().isEmpty()) {
       // If user is importing the existing event and if the existing event has parent identifier

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
@@ -72,7 +72,7 @@ public class AssociationEventCreationModel
       e.setParentID(
           matchingParentId
               .getParentData()
-              .format(matchingParentId.getObjectIdentifierSyntax(), 1)
+              .format(matchingParentId.getObjectIdentifierSyntax(), 1, matchingParentId.getDlURL())
               .get(0));
     } else if (typeInfo.getParentIdentifier() != null
         && typeInfo.getParentIdentifier().equals("")) {
@@ -98,14 +98,14 @@ public class AssociationEventCreationModel
     // Add source list
     if (typeInfo.getSources() != null && !typeInfo.getSources().isEmpty()) {
       e.setSourceList(
-          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src)).toList());
+          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src, typeInfo.getDlURL())).toList());
     }
 
     // Add Destination list
     if (typeInfo.getDestinations() != null && !typeInfo.getDestinations().isEmpty()) {
       e.setDestinationList(
           typeInfo.getDestinations().stream()
-              .map(dst -> DestinationFormatter.format(syntax, dst))
+              .map(dst -> DestinationFormatter.format(syntax, dst, typeInfo.getDlURL()))
               .toList());
     }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
@@ -78,14 +78,14 @@ public class ObjectEventCreationModel
     // Add source list
     if (typeInfo.getSources() != null && !typeInfo.getSources().isEmpty()) {
       e.setSourceList(
-          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src)).toList());
+          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src, typeInfo.getDlURL())).toList());
     }
 
     // Add Destination list
     if (typeInfo.getDestinations() != null && !typeInfo.getDestinations().isEmpty()) {
       e.setDestinationList(
           typeInfo.getDestinations().stream()
-              .map(dst -> DestinationFormatter.format(syntax, dst))
+              .map(dst -> DestinationFormatter.format(syntax, dst, typeInfo.getDlURL()))
               .toList());
     }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
@@ -72,7 +72,7 @@ public class TransactionEventCreationModel
       e.setParentID(
           matchingParentId
               .getParentData()
-              .format(matchingParentId.getObjectIdentifierSyntax(), 1)
+              .format(matchingParentId.getObjectIdentifierSyntax(), 1, matchingParentId.getDlURL())
               .get(0));
     } else if (typeInfo.getParentIdentifier() != null
         && typeInfo.getParentIdentifier().equals("")) {
@@ -97,14 +97,14 @@ public class TransactionEventCreationModel
     // Add source list
     if (typeInfo.getSources() != null && !typeInfo.getSources().isEmpty()) {
       e.setSourceList(
-          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src)).toList());
+          typeInfo.getSources().stream().map(src -> SourceFormatter.format(syntax, src, typeInfo.getDlURL())).toList());
     }
 
     // Add Destination list
     if (typeInfo.getDestinations() != null && !typeInfo.getDestinations().isEmpty()) {
       e.setDestinationList(
           typeInfo.getDestinations().stream()
-              .map(dst -> DestinationFormatter.format(syntax, dst))
+              .map(dst -> DestinationFormatter.format(syntax, dst, typeInfo.getDlURL()))
               .toList());
     }
 

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
@@ -141,7 +141,7 @@ public class TransformationEventCreationModel
                   m ->
                       outputEpcList.addAll(
                           m.getInstanceData()
-                              .format(m.getObjectIdentifierSyntax(), outputEpc.getEpcCount())));
+                              .format(m.getObjectIdentifierSyntax(), outputEpc.getEpcCount(), m.getDlURL())));
         }
       }
     }
@@ -189,7 +189,7 @@ public class TransformationEventCreationModel
                               .format(
                                   oq.getObjectIdentifierSyntax(),
                                   outputQuantity.getClassCount(),
-                                  outputQuantity.getQuantity())));
+                                  outputQuantity.getQuantity(), oq.getDlURL())));
         }
       }
     }

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/EPCISEventType.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/EPCISEventType.java
@@ -22,10 +22,7 @@ import io.openepcis.model.epcis.BizTransactionList;
 import io.openepcis.model.epcis.PersistentDisposition;
 import io.openepcis.model.epcis.QuantityList;
 import io.openepcis.model.epcis.SensorElementList;
-import io.openepcis.testdata.generator.constants.BusinessStep;
-import io.openepcis.testdata.generator.constants.Disposition;
-import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
-import io.openepcis.testdata.generator.constants.RecordTimeType;
+import io.openepcis.testdata.generator.constants.*;
 import io.openepcis.testdata.generator.format.ErrorDeclarationSyntax;
 import io.openepcis.testdata.generator.format.EventTime;
 import io.openepcis.testdata.generator.format.ReadPointBizLocationSyntax;
@@ -95,6 +92,11 @@ public class EPCISEventType implements Serializable {
       required = true)
   private @Valid IdentifierVocabularyType locationPartyIdentifierSyntax =
       IdentifierVocabularyType.URN;
+
+  @Schema(
+          type = SchemaType.STRING,
+          description = "(Optional) Custom URL used during the Digital Link URL generation. Default:https://ref.gs1.org")
+  private @Valid String dlURL = DomainName.VOCABULARY_DOMAIN;
 
   @NotNull(message = "Event type cannot be Null, should be Ordinary/Error")
   @Schema(

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/Identifier.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/Identifier.java
@@ -15,6 +15,7 @@
  */
 package io.openepcis.testdata.generator.template;
 
+import io.openepcis.testdata.generator.constants.DomainName;
 import io.openepcis.testdata.generator.constants.IdentifierVocabularyType;
 import io.openepcis.testdata.generator.identifier.classes.*;
 import io.openepcis.testdata.generator.identifier.classes.GenerateCPI;
@@ -49,6 +50,11 @@ public class Identifier {
   @NotNull(message = "Identifier Syntax cannot be Null, should be URN/WebURI")
   @Schema(description = "Identifiers generation format.", required = true)
   private @Valid IdentifierVocabularyType objectIdentifierSyntax = IdentifierVocabularyType.URN;
+
+  @Schema(
+          type = SchemaType.STRING,
+          description = "(Optional) Custom URL used during the Digital Link URL generation. Default:https://id.gs1.org")
+  private @Valid String dlURL = DomainName.IDENTIFIER_DOMAIN;
 
   @Schema(
       description = "Instance identifiers information required for identifier generation.",


### PR DESCRIPTION
@sboeckelmann 
This PR will add the option to customize the base Digital Link URL during the generation of the identifier. If the user has provided the custom base URL then it will used during the identifier generation in WebURI format and if not provided then the default URL `https://id.gs1.org` will be used. This is applicable for all the Instance/Class/Parent identifiers. 

Similarly, if a custom base URL is provided then the following fields use the custom URL during WebURI generation, if not then default `https://ref.gs1.org` will be used:
Readpoint/BizLocation.
Source/Destination
ErrorDeclaration - CorrectiveIDs. 

Kindly request you to review the changes and approve the PR.