### PR TITLE
OEPCIS-759: fixing issue during the parent id inheritance.

### DIFF
--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -244,11 +244,11 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
   /**
    * Method used for creating the EPCs based on the value provided for the field ReferencedIdentifier
    * @param parentTracker List of the parent identifiers node infprmation stored as parentTracker
-   * @param inheritParentIdFlag flag to detect if inheritParentIdentifiers need to be added or not. Inherited only for Object/TransformationEvent.
+   * @param inheritParentIdCountFlag flag to detect if inheritParentIdentifiers need to be added or not. Inherited only for Object/TransformationEvent.
    * @return returns List of EPC identifiers
    */
   public List<String> referencedEpcsIdentifierGenerator(
-      final List<EventIdentifierTracker> parentTracker, final Boolean inheritParentIdFlag) {
+      final List<EventIdentifierTracker> parentTracker, final Boolean inheritParentIdCountFlag) {
     // Create a List to store all the values associated Instance Identifiers
     final List<String> epcList = new ArrayList<>();
 
@@ -289,7 +289,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
       }
 
       //Add the identifiers from ParentID Count only if the inheriting event is ObjectEvent or TransformationEvent
-      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() != null && epc.getInheritParentCount() > 0 && !inheritParentIdFlag) {
+      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() != null && epc.getInheritParentCount() > 0 && inheritParentIdCountFlag) {
         // When user wants to inherit Parent-Ids from parent node into child node get the matching
         // Parent Identifiers. (AggregationEvent -> ObjectEvent)
         parentTracker.stream()

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -235,16 +235,20 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                 .findFirst()
                 .ifPresent(
                         t -> parentList.addAll(EventModelUtil.parentIdentifiers(t, epc.getInheritParentCount())));
-        epc.setInheritParentCount(0);
+        //epc.setInheritParentCount(0);
       }
     }
     return parentList;
   }
 
-  // Method used for creating the EPCs based on the value provided for the field
-  // ReferencedIdentifier
+  /**
+   * Method used for creating the EPCs based on the value provided for the field ReferencedIdentifier
+   * @param parentTracker List of the parent identifiers node infprmation stored as parentTracker
+   * @param inheritParentIdFlag flag to detect if inheritParentIdentifiers need to be added or not. Inherited only for Object/TransformationEvent.
+   * @return returns List of EPC identifiers
+   */
   public List<String> referencedEpcsIdentifierGenerator(
-      final List<EventIdentifierTracker> parentTracker) {
+      final List<EventIdentifierTracker> parentTracker, final Boolean inheritParentIdFlag) {
     // Create a List to store all the values associated Instance Identifiers
     final List<String> epcList = new ArrayList<>();
 
@@ -284,7 +288,8 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                 t -> epcList.addAll(EventModelUtil.instanceIdentifiers(t, epc.getEpcCount())));
       }
 
-      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() != null && epc.getInheritParentCount() > 0) {
+      //Add the identifiers from ParentID Count only if the inheriting event is ObjectEvent or TransformationEvent
+      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() != null && epc.getInheritParentCount() > 0 && !inheritParentIdFlag) {
         // When user wants to inherit Parent-Ids from parent node into child node get the matching
         // Parent Identifiers. (AggregationEvent -> ObjectEvent)
         parentTracker.stream()

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -235,7 +235,6 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                 .findFirst()
                 .ifPresent(
                         t -> parentList.addAll(EventModelUtil.parentIdentifiers(t, epc.getInheritParentCount())));
-        //epc.setInheritParentCount(0);
       }
     }
     return parentList;
@@ -258,7 +257,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
 
       // If the EventNode is directly connected to the IdentifiersNode then create the class
       // identifiers based on the provided identifiers info
-      if (epc.getIdentifierId() != 0 && epc.getEpcCount() != null && epc.getEpcCount() > 0) {
+      if (epc.getIdentifierId() != 0 && epc.getEpcCount() > 0) {
         // Get the matching identifiers
         var matchingIdentifier =
             identifiers.stream()
@@ -274,7 +273,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                   .getInstanceData()
                   .format(matchingIdentifier.getObjectIdentifierSyntax(), epc.getEpcCount(), matchingIdentifier.getDlURL()));
         }
-      } else if (epc.getParentNodeId() != 0 && epc.getEpcCount() != null && epc.getEpcCount() > 0) {
+      } else if (epc.getParentNodeId() != 0 && epc.getEpcCount() > 0) {
         // If referenced identifier contains the parent node id then obtain the identifiers from its
         // parent event and add it
 
@@ -289,7 +288,7 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
       }
 
       //Add the identifiers from ParentID Count only if the inheriting event is ObjectEvent or TransformationEvent
-      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() != null && epc.getInheritParentCount() > 0 && inheritParentIdCountFlag) {
+      if (epc.getParentNodeId() != 0 && epc.getInheritParentCount() > 0 && inheritParentIdCountFlag) {
         // When user wants to inherit Parent-Ids from parent node into child node get the matching
         // Parent Identifiers. (AggregationEvent -> ObjectEvent)
         parentTracker.stream()

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
@@ -129,7 +129,7 @@ public class AggregationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
+      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
 
       // Add the created EPC to the event
       if (!childEpcList.isEmpty()) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AggregationEventCreationModel.java
@@ -129,7 +129,7 @@ public class AggregationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker);
+      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
 
       // Add the created EPC to the event
       if (!childEpcList.isEmpty()) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
@@ -129,7 +129,7 @@ public class AssociationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
+      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
 
       // Add the created EPC to the event
       if (!childEpcList.isEmpty()) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AssociationEventCreationModel.java
@@ -129,7 +129,7 @@ public class AssociationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker);
+      final List<String> childEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
 
       // Add the created EPC to the event
       if (!childEpcList.isEmpty()) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
@@ -118,7 +118,7 @@ public class ObjectEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
+      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
 
       // Add all the instance identifiers created above to the ObjectEvent which will be created by
       // OpenEPCIS

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/ObjectEventCreationModel.java
@@ -118,7 +118,7 @@ public class ObjectEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker);
+      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
 
       // Add all the instance identifiers created above to the ObjectEvent which will be created by
       // OpenEPCIS

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
@@ -128,7 +128,7 @@ public class TransactionEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker);
+      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
 
       // Add all the instance identifiers created/inherited above to the TransactionEvent which will
       // be created by OpenEPCIS

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransactionEventCreationModel.java
@@ -128,7 +128,7 @@ public class TransactionEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
+      final List<String> epcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
 
       // Add all the instance identifiers created/inherited above to the TransactionEvent which will
       // be created by OpenEPCIS

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
@@ -98,7 +98,7 @@ public class TransformationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> inputEpcList = super.referencedEpcsIdentifierGenerator(parentTracker);
+      final List<String> inputEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
 
       // Add the created EPC to the event
       if (!inputEpcList.isEmpty()) {

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/TransformationEventCreationModel.java
@@ -98,7 +98,7 @@ public class TransformationEventCreationModel
 
       // A list which will store all the instance identifiers generated or inherited from the
       // parents by calling referencedEpcsIdentifierGenerator method in IdentifiersUtil
-      final List<String> inputEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, false);
+      final List<String> inputEpcList = super.referencedEpcsIdentifierGenerator(parentTracker, true);
 
       // Add the created EPC to the event
       if (!inputEpcList.isEmpty()) {

--- a/testdata-generator-ui/store/modules/ConnectorStore.js
+++ b/testdata-generator-ui/store/modules/ConnectorStore.js
@@ -59,17 +59,27 @@ export const mutations = {
   },
   // Function to populate the connector Array information with modal values
   populateConnectorInfo (state, connectorInfo) {
-    const connect = state.connectorArray.find(con => parseInt(con.source) === parseInt(state.currentConnector.output_id) && parseInt(con.target) === parseInt(state.currentConnector.input_id))
-    connect.epcCount = parseInt(connectorInfo.epcCount)
-    connect.inheritParentCount = parseInt(connectorInfo.inheritParentCount)
-    connect.classCount = parseInt(connectorInfo.classCount)
-    connect.quantity = parseInt(connectorInfo.quantity)
-    connect.hideInheritParentCount = connectorInfo.hideInheritParentCount
+    const connect = state.connectorArray.find(
+      con =>
+        parseInt(con.source) === parseInt(state.currentConnector.output_id) &&
+        parseInt(con.target) === parseInt(state.currentConnector.input_id)
+    )
+    connect.epcCount = parseInt(connectorInfo.epcCount) || 0
+    connect.inheritParentCount =
+      parseInt(connectorInfo.inheritParentCount) || 0
+    connect.classCount = parseInt(connectorInfo.classCount) || 0
+    connect.quantity = parseInt(connectorInfo.quantity) || 0
+    connect.hideInheritParentCount =
+      parseInt(connectorInfo.hideInheritParentCount) || 0
   },
   // Function to set the hideInheritParentCount based on the Source Node connected to Connector
   populateHideInheritParentCount (state, displayValue) {
     if (state.currentConnector !== undefined) {
-      const connect = state.connectorArray.find(con => parseInt(con.source) === parseInt(state.currentConnector.output_id) && parseInt(con.target) === parseInt(state.currentConnector.input_id))
+      const connect = state.connectorArray.find(
+        con =>
+          parseInt(con.source) === parseInt(state.currentConnector.output_id) &&
+          parseInt(con.target) === parseInt(state.currentConnector.input_id)
+      )
       if (connect !== undefined) {
         connect.hideInheritParentCount = displayValue
       }
@@ -77,7 +87,14 @@ export const mutations = {
   },
   // Function to remove the connector information from connector Array if the connector is deleted
   removeConnectorInfo (state, connectorInfo) {
-    state.connectorArray.splice(state.connectorArray.findIndex(con => parseInt(con.source) === parseInt(connectorInfo.output_id) && parseInt(con.target) === parseInt(connectorInfo.input_id)), 1)
+    state.connectorArray.splice(
+      state.connectorArray.findIndex(
+        con =>
+          parseInt(con.source) === parseInt(connectorInfo.output_id) &&
+          parseInt(con.target) === parseInt(connectorInfo.input_id)
+      ),
+      1
+    )
   },
   // Function to populate all the Connector information into the connectorArray during the import of the supply chain template
   populateConnectorArray (state, connectorArray) {

--- a/testdata-generator-ui/store/modules/RelationsBuilder.js
+++ b/testdata-generator-ui/store/modules/RelationsBuilder.js
@@ -159,10 +159,10 @@ export const actions = {
             ) {
               const identifierObj = {
                 identifierId: state.diagram[identifierNode].id,
-                epcCount: connectionInfo.epcCount,
-                inheritParentCount: connectionInfo.inheritParentCount,
-                classCount: connectionInfo.classCount,
-                quantity: connectionInfo.quantity
+                epcCount: connectionInfo.epcCount || 0,
+                inheritParentCount: connectionInfo.inheritParentCount || 0,
+                classCount: connectionInfo.classCount || 0,
+                quantity: connectionInfo.quantity || 0
               }
 
               // If the eventType is TransformationEvent and if the identifiers node is connected to input_1 then treat it as input EPC/Quantity
@@ -319,10 +319,10 @@ export const actions = {
                 function (identifier) {
                   const refIdObj = {
                     parentNodeId: parentNodeInfo.eventId,
-                    epcCount: connectionInfo.epcCount,
-                    inheritParentCount: connectionInfo.inheritParentCount,
-                    classCount: connectionInfo.classCount,
-                    quantity: connectionInfo.quantity
+                    epcCount: connectionInfo.epcCount || 0,
+                    inheritParentCount: connectionInfo.inheritParentCount || 0,
+                    classCount: connectionInfo.classCount || 0,
+                    quantity: connectionInfo.quantity || 0
                   }
                   return refIdObj
                 }


### PR DESCRIPTION
@sboeckelmann 

This PR will fix the inheritance issue associated with AssociationEvent -> AggregationEvent or vice versa. This was happening due to we were resetting the value. Hence, it was not inherited. I have also tested with different event types and seems to be working appropriately.

Kindly request you to review the changes and approve the PR.