### PR TITLE
Edg 33 certification info string to object

### DIFF
--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -117,8 +117,10 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
                   // Return an empty stream if neither are present
                   return Stream.empty();
                 }).collect(Collectors.toList());
-        
-        epcisEvent.setCertificationInfo(formattedCertificationInfo);
+
+        if (!formattedCertificationInfo.isEmpty()) {
+          epcisEvent.setCertificationInfo(formattedCertificationInfo);
+        }
       }
 
       // User extensions addition

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/model/AbstractEventCreationModel.java
@@ -103,9 +103,22 @@ public abstract class AbstractEventCreationModel<T extends EPCISEventType, E ext
         epcisEvent.setSensorElementList(typeInfo.getSensorElementList());
       }
 
-      // Add the certificationInfo
+      // Add the certificationInfo by formatting from UserExtension syntax
       if (typeInfo.getCertificationInfo() != null && !typeInfo.getCertificationInfo().isEmpty()) {
-        epcisEvent.setCertificationInfo(typeInfo.getCertificationInfo());
+        final List<Object> formattedCertificationInfo = typeInfo.getCertificationInfo().stream()
+                .flatMap(root -> {
+                  if (CollectionUtils.isNotEmpty(root.getChildren())) {
+                    // Stream over children if present
+                    return root.getChildren().stream().flatMap(c -> c.toMap().entrySet().stream());
+                  } else if (root.getRawJsonld() instanceof Map) {
+                    // Stream over rawJsonld if it's a Map
+                    return root.toMap().entrySet().stream();
+                  }
+                  // Return an empty stream if neither are present
+                  return Stream.empty();
+                }).collect(Collectors.toList());
+        
+        epcisEvent.setCertificationInfo(formattedCertificationInfo);
       }
 
       // User extensions addition

--- a/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/EPCISEventType.java
+++ b/testdata-generator-common/src/main/java/io/openepcis/testdata/generator/template/EPCISEventType.java
@@ -192,9 +192,9 @@ public class EPCISEventType implements Serializable {
   private @Valid String hashAlgorithm;
 
   @Schema(
-      type = SchemaType.STRING,
-      description = "URL at which certification details can be found.")
-  private String certificationInfo;
+      type = SchemaType.ARRAY,
+      description = "Certification information associated with the event in GS1 Web Vocabulary or Raw JSON-LD format")
+  private List<@Valid UserExtensionSyntax> certificationInfo;
 
   @Schema(
       type = SchemaType.ARRAY,


### PR DESCRIPTION
@sboeckelmann 

This PR will support the formatting and addition of certificationInfo as List<Object> instead of the previous code allowing only String.

Could you please review the PR and approve it?